### PR TITLE
Automate stable and dev Morphe updates

### DIFF
--- a/.github/scripts/sync_upstream.py
+++ b/.github/scripts/sync_upstream.py
@@ -1,0 +1,738 @@
+#!/usr/bin/env python3
+"""Prepare and publish automated Morphe upstream updates.
+
+The prepare phase runs with a read-only GITHUB_TOKEN. It merges an exact
+upstream release tag, builds and validates the patch bundle, commits the
+candidate locally, and exports an incremental Git bundle plus a release plan.
+
+The publish phase runs in a separate job with write permissions. It validates
+the prepared bundle and artifact, publishes the release, and advances the
+target branch. It never executes code received from upstream.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import zipfile
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+UPSTREAM_URL = "https://github.com/MorpheApp/morphe-patches.git"
+PROJECT_REPOSITORY = "sashade8-ship-it/dual-vot-patches"
+
+PROJECT_OWNED_PATHS = (
+    "README.md",
+    "CHANGELOG.md",
+    "patches-bundle.json",
+    "patches-list.json",
+    "CONTRIBUTING.md",
+    ".github/ISSUE_TEMPLATE/bug_report.yml",
+    ".github/ISSUE_TEMPLATE/feature_request.yml",
+    ".github/workflows/crowdin_pull.yml",
+    ".github/workflows/crowdin_push.yml",
+    ".github/workflows/release.yml",
+    ".github/workflows/upstream_sync.yml",
+    ".github/workflows/upstream_sync_channel.yml",
+    ".github/scripts/sync_upstream.py",
+)
+
+UPSTREAM_FILES_REMOVED_FROM_DERIVATIVE = (
+    ".github/workflows/open_pull_request.yml",
+    "patches-bundle.png",
+)
+
+REQUIRED_SOURCE_PATHS = (
+    "extensions/youtube/src/main/java/app/morphe/extension/youtube/"
+    "patches/voiceovertranslation/VoiceOverTranslationCoordinator.java",
+    "extensions/youtube/src/main/java/app/morphe/extension/youtube/"
+    "patches/voiceovertranslation/yandex/YandexVoiceOverTranslationPatch.java",
+    "patches/src/main/kotlin/app/morphe/patches/youtube/video/"
+    "voiceovertranslation/YandexVoiceOverTranslationPatch.kt",
+)
+
+REQUIRED_PATCH_NAMES = (
+    "Voice over translation",
+    "Yandex voice-over translation",
+)
+
+
+class SyncError(RuntimeError):
+    """An expected safety stop that should be reported as an automation issue."""
+
+
+@dataclass(frozen=True)
+class ReleasePlan:
+    channel: str
+    branch: str
+    upstream_version: str
+    version: str
+    commit: str
+    release: bool
+    tag: str | None
+    artifact_name: str | None
+    artifact_sha256: str | None
+    release_title: str | None
+    release_notes: str | None
+
+
+def run(
+    *args: str,
+    check: bool = True,
+    capture: bool = False,
+    cwd: Path = ROOT,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    print("+", " ".join(args), flush=True)
+    completed = subprocess.run(
+        args,
+        cwd=cwd,
+        env=env,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE if capture else None,
+    )
+    if check and completed.returncode != 0:
+        details = ""
+        if capture:
+            details = f"\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+        raise SyncError(
+            f"Command failed with exit code {completed.returncode}: "
+            f"{' '.join(args)}{details}"
+        )
+    return completed
+
+
+def output_of(*args: str, cwd: Path = ROOT) -> str:
+    return run(*args, capture=True, cwd=cwd).stdout.strip()
+
+
+def write_github_output(name: str, value: str) -> None:
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with Path(output).open("a", encoding="utf-8") as stream:
+            stream.write(f"{name}={value}\n")
+    print(f"{name}={value}")
+
+
+def git_path_exists(ref: str, path: str) -> bool:
+    return run("git", "cat-file", "-e", f"{ref}:{path}", check=False).returncode == 0
+
+
+def restore_path_from(ref: str, path: str) -> None:
+    if git_path_exists(ref, path):
+        run("git", "restore", f"--source={ref}", "--staged", "--worktree", "--", path)
+    else:
+        run("git", "rm", "-rf", "--ignore-unmatch", "--", path)
+
+
+def unresolved_paths() -> list[str]:
+    result = output_of("git", "diff", "--name-only", "--diff-filter=U")
+    return [line for line in result.splitlines() if line]
+
+
+def merge_ref(ref: str, project_preference: str, label: str) -> bool:
+    """Merge ref without committing and resolve only explicitly owned files.
+
+    Unknown source conflicts stop the automation. This is the central guard
+    that prevents a build from silently dropping upstream or Dual VoT code.
+    """
+
+    before = output_of("git", "rev-parse", "HEAD")
+    if run("git", "merge-base", "--is-ancestor", ref, "HEAD", check=False).returncode == 0:
+        return False
+
+    merge = run("git", "merge", "--no-commit", "--no-ff", ref, check=False)
+    if merge.returncode not in (0, 1):
+        raise SyncError(f"Could not start merge of {label}")
+
+    preferred_ref = "HEAD" if project_preference == "ours" else "MERGE_HEAD"
+    for path in PROJECT_OWNED_PATHS:
+        restore_path_from(preferred_ref, path)
+
+    # The upstream version is authoritative; the Dual suffix is added later.
+    if "gradle.properties" in unresolved_paths():
+        restore_path_from("MERGE_HEAD", "gradle.properties")
+
+    for path in UPSTREAM_FILES_REMOVED_FROM_DERIVATIVE:
+        run("git", "rm", "-rf", "--ignore-unmatch", "--", path)
+
+    remaining = unresolved_paths()
+    if remaining:
+        run("git", "merge", "--abort", check=False)
+        raise SyncError(
+            "Manual source merge required. Unresolved paths: "
+            + ", ".join(remaining)
+        )
+
+    # A merge may contain only changes to project-owned generated files that
+    # were restored above. Commit the merge even when its tree is unchanged so
+    # the upstream tag becomes an ancestor and is not retried forever.
+    run("git", "commit", "--no-edit")
+
+    return output_of("git", "rev-parse", "HEAD") != before
+
+
+def json_from_git(ref: str, path: str) -> dict:
+    raw = output_of("git", "show", f"{ref}:{path}")
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise SyncError(f"Invalid JSON in {ref}:{path}: {error}") from error
+    if not isinstance(value, dict):
+        raise SyncError(f"Expected an object in {ref}:{path}")
+    return value
+
+
+def bundle_version_from_git(ref: str) -> str:
+    version = json_from_git(ref, "patches-bundle.json").get("version")
+    if not isinstance(version, str) or not version.strip():
+        raise SyncError(f"Missing version in {ref}:patches-bundle.json")
+    return version.strip().removeprefix("v")
+
+
+def upstream_base(version: str) -> str:
+    return version.split("-dualvot.", 1)[0].removeprefix("v")
+
+
+def validate_version(version: str) -> None:
+    if not re.fullmatch(r"\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?", version):
+        raise SyncError(f"Unsafe or unsupported upstream version: {version!r}")
+
+
+def set_gradle_version(version: str) -> None:
+    path = ROOT / "gradle.properties"
+    text = path.read_text(encoding="utf-8")
+    updated, count = re.subn(
+        r"(?m)^version\s*=\s*.*$",
+        f"version = {version}",
+        text,
+        count=1,
+    )
+    if count != 1:
+        raise SyncError("Could not update version in gradle.properties")
+    path.write_text(updated, encoding="utf-8")
+
+
+def extract_dual_sections(changelog: str) -> list[str]:
+    headings = list(re.finditer(r"(?m)^## (.+)$", changelog))
+    sections: list[str] = []
+    for index, heading in enumerate(headings):
+        title = heading.group(1)
+        if "-dualvot." not in title.lower():
+            continue
+        end = headings[index + 1].start() if index + 1 < len(headings) else len(changelog)
+        sections.append(changelog[heading.start() : end].strip())
+    return sections
+
+
+def update_changelog(
+    version: str,
+    upstream_version: str,
+    previous_changelog: str,
+    upstream_changelog: str,
+    channel: str,
+) -> None:
+    date = datetime.now(timezone.utc).date().isoformat()
+    channel_label = "stable" if channel == "stable" else "pre-release"
+    new_section = f"""## {version} ({date})
+
+### Automated Morphe update
+
+* Update the {channel_label} base to [Morphe Patches {upstream_version}](
+  https://github.com/MorpheApp/morphe-patches/releases/tag/v{upstream_version}).
+* Preserve Google/other and Yandex voice-over translation, mutual exclusion,
+  volume controls, and automatic reset when the video changes.
+* Build and structural Dual VoT checks passed before publication.
+""".strip()
+
+    historical = [
+        section
+        for section in extract_dual_sections(previous_changelog)
+        if not section.startswith(f"## {version} ")
+    ]
+    combined = "\n\n".join([new_section, *historical, upstream_changelog.strip()])
+    (ROOT / "CHANGELOG.md").write_text(combined.rstrip() + "\n", encoding="utf-8")
+
+
+def release_notes(version: str, upstream_version: str, channel: str) -> str:
+    release_kind = "Stable" if channel == "stable" else "Pre-release"
+    return f"""## Dual VoT Patches {version}
+
+{release_kind} automated update based on Morphe Patches {upstream_version}.
+
+### Included
+
+- Google/other and Yandex voice-over translation in one patch bundle.
+- Separate player controls with mutual exclusion.
+- Dual VoT volume controls and automatic reset when the video changes.
+- Requests for previously untranslated Yandex videos.
+
+### Validation
+
+- Android patch bundle compiled successfully.
+- Both translation patches are present in generated metadata.
+- Required Dual VoT integration sources and bundle manifest were verified.
+
+This release was produced automatically. Runtime regressions that cannot be
+detected by compilation should be reported in this repository.
+""".strip()
+
+
+def update_bundle_metadata(
+    version: str,
+    notes: str,
+) -> None:
+    created_at = datetime.now(timezone.utc).replace(tzinfo=None).isoformat(timespec="seconds")
+    data = {
+        "created_at": created_at,
+        "description": notes,
+        "download_url": (
+            f"https://github.com/{PROJECT_REPOSITORY}/releases/download/"
+            f"v{version}/patches-{version}.mpp"
+        ),
+        "signature_download_url": "",
+        "version": version,
+    }
+    (ROOT / "patches-bundle.json").write_text(
+        json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def gradle_environment() -> dict[str, str]:
+    env = os.environ.copy()
+    token = env.get("GITHUB_TOKEN") or env.get("GH_TOKEN")
+    if not token:
+        raise SyncError("GITHUB_TOKEN is required to read Morphe GitHub Packages")
+    env["GITHUB_TOKEN"] = token
+    env.setdefault("GITHUB_ACTOR", os.environ.get("GITHUB_ACTOR", "github-actions[bot]"))
+    return env
+
+
+def build_and_generate(repository: str, branch: str) -> None:
+    gradlew = "gradlew.bat" if os.name == "nt" else "./gradlew"
+    run(
+        gradlew,
+        ":patches:buildAndroid",
+        "generatePatchesList",
+        "--no-daemon",
+        env=gradle_environment(),
+    )
+    run(
+        sys.executable,
+        ".github/scripts/generate_patches_readme.py",
+        repository,
+        branch,
+        "patches-list.json",
+        "README.md",
+    )
+
+
+def parse_manifest(raw: str) -> dict[str, str]:
+    unfolded = re.sub(r"\r?\n ", "", raw)
+    values: dict[str, str] = {}
+    for line in unfolded.splitlines():
+        if ": " in line:
+            key, value = line.split(": ", 1)
+            values[key] = value
+    return values
+
+
+def validate_candidate(version: str) -> Path:
+    for relative in REQUIRED_SOURCE_PATHS:
+        if not (ROOT / relative).is_file():
+            raise SyncError(f"Required Dual VoT source is missing: {relative}")
+
+    patches_list = json.loads((ROOT / "patches-list.json").read_text(encoding="utf-8"))
+    if patches_list.get("version") != version:
+        raise SyncError(
+            f"patches-list.json has version {patches_list.get('version')!r}, "
+            f"expected {version!r}"
+        )
+    names = {
+        patch.get("name")
+        for patch in patches_list.get("patches", [])
+        if isinstance(patch, dict)
+    }
+    missing_names = [name for name in REQUIRED_PATCH_NAMES if name not in names]
+    if missing_names:
+        raise SyncError("Required patches missing from metadata: " + ", ".join(missing_names))
+
+    artifact = ROOT / "patches" / "build" / "libs" / f"patches-{version}.mpp"
+    if not artifact.is_file() or artifact.stat().st_size < 1_000_000:
+        raise SyncError(f"Missing or truncated Android patch bundle: {artifact}")
+
+    with zipfile.ZipFile(artifact) as archive:
+        try:
+            manifest_raw = archive.read("META-INF/MANIFEST.MF").decode("utf-8")
+        except KeyError as error:
+            raise SyncError("Patch bundle has no META-INF/MANIFEST.MF") from error
+    manifest = parse_manifest(manifest_raw)
+    if manifest.get("Version") != version:
+        raise SyncError(
+            f"Bundle manifest version {manifest.get('Version')!r}, expected {version!r}"
+        )
+    if manifest.get("Name") != "Dual VoT Patches":
+        raise SyncError(f"Unexpected bundle name: {manifest.get('Name')!r}")
+
+    metadata = json.loads((ROOT / "patches-bundle.json").read_text(encoding="utf-8"))
+    if metadata.get("version") != version:
+        raise SyncError("patches-bundle.json version mismatch")
+
+    return artifact
+
+
+def configure_git_identity() -> None:
+    run("git", "config", "user.name", "dual-vot-updater[bot]")
+    run(
+        "git",
+        "config",
+        "user.email",
+        "41898282+github-actions[bot]@users.noreply.github.com",
+    )
+
+
+def checkout_channel(branch: str) -> None:
+    run("git", "fetch", "--no-tags", "origin", "main", "dev")
+    run("git", "fetch", "--tags", "upstream", "main", "dev")
+    run("git", "checkout", "-B", branch, f"origin/{branch}")
+
+
+def ensure_upstream_remote() -> None:
+    remotes = output_of("git", "remote").splitlines()
+    if "upstream" in remotes:
+        run("git", "remote", "set-url", "upstream", UPSTREAM_URL)
+    else:
+        run("git", "remote", "add", "upstream", UPSTREAM_URL)
+
+
+def create_incremental_bundle(output_dir: Path, branch: str) -> Path:
+    bundle = output_dir / "candidate.bundle"
+    run(
+        "git",
+        "bundle",
+        "create",
+        str(bundle),
+        "HEAD",
+        f"^origin/{branch}",
+    )
+    run("git", "bundle", "verify", str(bundle))
+    return bundle
+
+
+def prepare(channel: str, output_dir: Path, repository: str) -> None:
+    branch = "main" if channel == "stable" else "dev"
+    upstream_branch = "main" if channel == "stable" else "dev"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    configure_git_identity()
+    ensure_upstream_remote()
+    checkout_channel(branch)
+
+    upstream_version = bundle_version_from_git(f"upstream/{upstream_branch}")
+    validate_version(upstream_version)
+    upstream_tag = f"refs/tags/v{upstream_version}"
+    if run("git", "show-ref", "--verify", "--quiet", upstream_tag, check=False).returncode != 0:
+        raise SyncError(f"Upstream release tag v{upstream_version} does not exist")
+
+    local_version = bundle_version_from_git("HEAD")
+    local_base = upstream_base(local_version)
+    previous_changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    branch_changed = False
+
+    if channel == "dev":
+        stable_version = bundle_version_from_git("origin/main")
+        stable_base = upstream_base(stable_version)
+        dev_matches_stable = upstream_version == stable_base
+        branch_changed |= merge_ref(
+            "origin/main",
+            project_preference="theirs" if dev_matches_stable else "ours",
+            label="the latest Dual VoT stable branch",
+        )
+        local_version = bundle_version_from_git("HEAD")
+        local_base = upstream_base(local_version)
+
+        if dev_matches_stable:
+            if not branch_changed:
+                write_github_output("updated", "false")
+                return
+            commit = output_of("git", "rev-parse", "HEAD")
+            plan = ReleasePlan(
+                channel=channel,
+                branch=branch,
+                upstream_version=upstream_version,
+                version=stable_version,
+                commit=commit,
+                release=False,
+                tag=None,
+                artifact_name=None,
+                artifact_sha256=None,
+                release_title=None,
+                release_notes=None,
+            )
+            create_incremental_bundle(output_dir, branch)
+            (output_dir / "plan.json").write_text(
+                json.dumps(asdict(plan), ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            write_github_output("updated", "true")
+            write_github_output("version", stable_version)
+            return
+
+    if upstream_version == local_base:
+        if branch_changed:
+            commit = output_of("git", "rev-parse", "HEAD")
+            plan = ReleasePlan(
+                channel=channel,
+                branch=branch,
+                upstream_version=upstream_version,
+                version=local_version,
+                commit=commit,
+                release=False,
+                tag=None,
+                artifact_name=None,
+                artifact_sha256=None,
+                release_title=None,
+                release_notes=None,
+            )
+            create_incremental_bundle(output_dir, branch)
+            (output_dir / "plan.json").write_text(
+                json.dumps(asdict(plan), ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            write_github_output("updated", "true")
+            write_github_output("version", local_version)
+        else:
+            write_github_output("updated", "false")
+        return
+
+    upstream_changelog = output_of("git", "show", f"{upstream_tag}:CHANGELOG.md")
+    merge_ref(upstream_tag, project_preference="ours", label=f"Morphe {upstream_version}")
+
+    version = f"{upstream_version}-dualvot.1"
+    validate_version(version)
+    set_gradle_version(version)
+    notes = release_notes(version, upstream_version, channel)
+    update_changelog(
+        version,
+        upstream_version,
+        previous_changelog,
+        upstream_changelog,
+        channel,
+    )
+    update_bundle_metadata(version, notes)
+    build_and_generate(repository, branch)
+
+    # generatePatchesList is authoritative, but the release version must stay
+    # exactly aligned across the bundle, list, JSON and tag.
+    patches_list_path = ROOT / "patches-list.json"
+    patches_list = json.loads(patches_list_path.read_text(encoding="utf-8"))
+    patches_list["version"] = version
+    patches_list_path.write_text(
+        json.dumps(patches_list, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    run(
+        sys.executable,
+        ".github/scripts/generate_patches_readme.py",
+        repository,
+        branch,
+        "patches-list.json",
+        "README.md",
+    )
+
+    artifact = validate_candidate(version)
+    run("git", "add", "-A")
+    if not output_of("git", "status", "--porcelain"):
+        raise SyncError("Upstream version changed but candidate has no Git changes")
+    run(
+        "git",
+        "commit",
+        "-m",
+        f"chore: update {channel} base to Morphe {upstream_version}",
+    )
+
+    commit = output_of("git", "rev-parse", "HEAD")
+    artifact_sha256 = hashlib.sha256(artifact.read_bytes()).hexdigest()
+    copied_artifact = output_dir / artifact.name
+    shutil.copy2(artifact, copied_artifact)
+
+    plan = ReleasePlan(
+        channel=channel,
+        branch=branch,
+        upstream_version=upstream_version,
+        version=version,
+        commit=commit,
+        release=True,
+        tag=f"v{version}",
+        artifact_name=artifact.name,
+        artifact_sha256=artifact_sha256,
+        release_title=f"Dual VoT Patches {version}",
+        release_notes=notes,
+    )
+    create_incremental_bundle(output_dir, branch)
+    (output_dir / "plan.json").write_text(
+        json.dumps(asdict(plan), ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    write_github_output("updated", "true")
+    write_github_output("version", version)
+
+
+def load_plan(input_dir: Path) -> ReleasePlan:
+    raw = json.loads((input_dir / "plan.json").read_text(encoding="utf-8"))
+    allowed = {"stable", "dev"}
+    if raw.get("channel") not in allowed:
+        raise SyncError("Invalid channel in release plan")
+    expected_branch = "main" if raw["channel"] == "stable" else "dev"
+    if raw.get("branch") != expected_branch:
+        raise SyncError("Release plan branch does not match channel")
+    validate_version(str(raw.get("upstream_version", "")))
+    validate_version(str(raw.get("version", "")))
+    commit = str(raw.get("commit", ""))
+    if not re.fullmatch(r"[0-9a-f]{40}", commit):
+        raise SyncError("Invalid commit in release plan")
+    return ReleasePlan(**raw)
+
+
+def cleanup_release(repository: str, tag: str) -> None:
+    run(
+        "gh",
+        "release",
+        "delete",
+        tag,
+        "--repo",
+        repository,
+        "--yes",
+        "--cleanup-tag",
+        check=False,
+    )
+    run("git", "push", "origin", f":refs/tags/{tag}", check=False)
+
+
+def publish(input_dir: Path, repository: str) -> None:
+    plan = load_plan(input_dir)
+    run("git", "fetch", "--no-tags", "origin", plan.branch)
+    candidate_ref = "refs/remotes/automation/candidate"
+    run(
+        "git",
+        "fetch",
+        str(input_dir / "candidate.bundle"),
+        f"HEAD:{candidate_ref}",
+    )
+    candidate = output_of("git", "rev-parse", candidate_ref)
+    if candidate != plan.commit:
+        raise SyncError("Candidate bundle commit does not match release plan")
+    if (
+        run(
+            "git",
+            "merge-base",
+            "--is-ancestor",
+            f"origin/{plan.branch}",
+            candidate_ref,
+            check=False,
+        ).returncode
+        != 0
+    ):
+        raise SyncError(
+            f"Remote {plan.branch} changed incompatibly while the candidate was building"
+        )
+
+    if not plan.release:
+        run("git", "push", "origin", f"{candidate_ref}:refs/heads/{plan.branch}")
+        return
+
+    if not plan.tag or not plan.artifact_name or not plan.artifact_sha256:
+        raise SyncError("Incomplete release plan")
+    artifact = input_dir / plan.artifact_name
+    if not artifact.is_file():
+        raise SyncError(f"Prepared artifact is missing: {plan.artifact_name}")
+    digest = hashlib.sha256(artifact.read_bytes()).hexdigest()
+    if digest != plan.artifact_sha256:
+        raise SyncError("Prepared artifact SHA-256 mismatch")
+
+    if run("gh", "release", "view", plan.tag, "--repo", repository, check=False).returncode == 0:
+        raise SyncError(f"Release {plan.tag} already exists")
+    if run("git", "ls-remote", "--exit-code", "--tags", "origin", plan.tag, check=False).returncode == 0:
+        raise SyncError(f"Tag {plan.tag} already exists")
+
+    run("git", "tag", "-a", plan.tag, candidate_ref, "-m", plan.release_title or plan.tag)
+    run("git", "push", "origin", f"refs/tags/{plan.tag}")
+
+    notes_file = input_dir / "release-notes.md"
+    notes_file.write_text((plan.release_notes or "").rstrip() + "\n", encoding="utf-8")
+    release_command = [
+        "gh",
+        "release",
+        "create",
+        plan.tag,
+        str(artifact),
+        "--repo",
+        repository,
+        "--verify-tag",
+        "--title",
+        plan.release_title or plan.tag,
+        "--notes-file",
+        str(notes_file),
+    ]
+    if plan.channel == "dev":
+        release_command.append("--prerelease")
+    else:
+        release_command.append("--latest")
+
+    try:
+        run(*release_command)
+        run("git", "push", "origin", f"{candidate_ref}:refs/heads/{plan.branch}")
+    except Exception:
+        cleanup_release(repository, plan.tag)
+        raise
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare_parser = subparsers.add_parser("prepare")
+    prepare_parser.add_argument("--channel", choices=("stable", "dev"), required=True)
+    prepare_parser.add_argument("--output-dir", type=Path, required=True)
+    prepare_parser.add_argument(
+        "--repository",
+        default=os.environ.get("GITHUB_REPOSITORY", PROJECT_REPOSITORY),
+    )
+
+    publish_parser = subparsers.add_parser("publish")
+    publish_parser.add_argument("--input-dir", type=Path, required=True)
+    publish_parser.add_argument(
+        "--repository",
+        default=os.environ.get("GITHUB_REPOSITORY", PROJECT_REPOSITORY),
+    )
+
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.command == "prepare":
+            prepare(args.channel, args.output_dir.resolve(), args.repository)
+        else:
+            publish(args.input_dir.resolve(), args.repository)
+    except SyncError as error:
+        print(f"::error::{error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_sync_upstream.py
+++ b/.github/scripts/test_sync_upstream.py
@@ -1,0 +1,70 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("sync_upstream.py")
+SPEC = importlib.util.spec_from_file_location("sync_upstream", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+sync_upstream = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = sync_upstream
+SPEC.loader.exec_module(sync_upstream)
+
+
+class SyncUpstreamTests(unittest.TestCase):
+    def test_extracts_official_base_from_dual_version(self):
+        self.assertEqual(
+            sync_upstream.upstream_base("1.37.0-dualvot.3"),
+            "1.37.0",
+        )
+        self.assertEqual(
+            sync_upstream.upstream_base("1.38.0-dev.2-dualvot.1"),
+            "1.38.0-dev.2",
+        )
+
+    def test_accepts_stable_and_prerelease_versions(self):
+        for version in ("1.38.0", "1.38.0-dev.2", "1.38.0-dev.2-dualvot.1"):
+            sync_upstream.validate_version(version)
+
+    def test_rejects_version_that_could_become_a_command_argument(self):
+        with self.assertRaises(sync_upstream.SyncError):
+            sync_upstream.validate_version("1.38.0;echo-danger")
+
+    def test_extracts_only_dual_changelog_sections(self):
+        changelog = """## 1.38.0-dualvot.1 (2026-07-27)
+
+Dual update.
+
+## 1.38.0 (2026-07-27)
+
+Upstream update.
+
+## 1.37.0-dualvot.3 (2026-07-26)
+
+Older Dual update.
+"""
+        self.assertEqual(
+            sync_upstream.extract_dual_sections(changelog),
+            [
+                "## 1.38.0-dualvot.1 (2026-07-27)\n\nDual update.",
+                "## 1.37.0-dualvot.3 (2026-07-26)\n\nOlder Dual update.",
+            ],
+        )
+
+    def test_unfolds_wrapped_manifest_values(self):
+        manifest = (
+            "Manifest-Version: 1.0\r\n"
+            "Name: Dual VoT Patches\r\n"
+            "Description: Google and Yandex voice-over tran\r\n"
+            " slation\r\n"
+            "Version: 1.38.0-dualvot.1\r\n"
+        )
+        parsed = sync_upstream.parse_manifest(manifest)
+        self.assertEqual(parsed["Name"], "Dual VoT Patches")
+        self.assertEqual(parsed["Description"], "Google and Yandex voice-over translation")
+        self.assertEqual(parsed["Version"], "1.38.0-dualvot.1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - dev
+      - main
 
 jobs:
   release:
@@ -24,7 +25,10 @@ jobs:
           java-version: '21'
 
       - name: Cache Gradle
-        uses: burrunan/gradle-cache-action@v3
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Test upstream automation
+        run: python .github/scripts/test_sync_upstream.py
 
       - name: Build
         env:

--- a/.github/workflows/crowdin_pull.yml
+++ b/.github/workflows/crowdin_pull.yml
@@ -47,7 +47,7 @@ jobs:
           clean: true
 
       - name: Cache Gradle
-        uses: burrunan/gradle-cache-action@v3
+        uses: gradle/actions/setup-gradle@v6
 
       # Step 2: Run string checks on the crowdin branch
       - name: Check strings on crowdin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           java-version: '21'
 
       - name: Cache Gradle
-        uses: burrunan/gradle-cache-action@v3
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build
         env:

--- a/.github/workflows/upstream_sync.yml
+++ b/.github/workflows/upstream_sync.yml
@@ -1,0 +1,54 @@
+name: Sync Morphe upstream
+
+on:
+  schedule:
+    - cron: '23 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Channel to check
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - stable
+          - dev
+
+concurrency:
+  group: dual-vot-upstream-sync
+  cancel-in-progress: false
+
+jobs:
+  stable:
+    name: Stable channel
+    if: >-
+      github.event_name == 'schedule' ||
+      inputs.channel == 'all' ||
+      inputs.channel == 'stable'
+    permissions:
+      contents: write
+      packages: read
+      issues: write
+    uses: ./.github/workflows/upstream_sync_channel.yml
+    with:
+      channel: stable
+
+  dev:
+    name: Pre-release channel
+    needs: stable
+    if: >-
+      always() &&
+      (needs.stable.result == 'success' || needs.stable.result == 'skipped') &&
+      (
+        github.event_name == 'schedule' ||
+        inputs.channel == 'all' ||
+        inputs.channel == 'dev'
+      )
+    permissions:
+      contents: write
+      packages: read
+      issues: write
+    uses: ./.github/workflows/upstream_sync_channel.yml
+    with:
+      channel: dev

--- a/.github/workflows/upstream_sync_channel.yml
+++ b/.github/workflows/upstream_sync_channel.yml
@@ -1,0 +1,157 @@
+name: Sync one Morphe channel
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: Channel to synchronize
+        required: true
+        type: string
+
+jobs:
+  prepare:
+    name: Prepare ${{ inputs.channel }} update
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      updated: ${{ steps.prepare.outputs.updated }}
+      version: ${{ steps.prepare.outputs.version }}
+    steps:
+      - name: Checkout target branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.channel == 'stable' && 'main' || 'dev' }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: Cache Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Prepare and validate candidate
+        id: prepare
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          python .github/scripts/sync_upstream.py prepare
+          --channel "${{ inputs.channel }}"
+          --output-dir "$RUNNER_TEMP/upstream-candidate"
+
+      - name: Upload validated candidate
+        if: steps.prepare.outputs.updated == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: upstream-${{ inputs.channel }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/upstream-candidate
+          if-no-files-found: error
+          retention-days: 3
+
+  publish:
+    name: Publish ${{ inputs.channel }} update
+    needs: prepare
+    if: needs.prepare.outputs.updated == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout target branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.channel == 'stable' && 'main' || 'dev' }}
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: Download validated candidate
+        uses: actions/download-artifact@v8
+        with:
+          name: upstream-${{ inputs.channel }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/upstream-candidate
+
+      - name: Publish branch and release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          python .github/scripts/sync_upstream.py publish
+          --input-dir "$RUNNER_TEMP/upstream-candidate"
+
+  report:
+    name: Report ${{ inputs.channel }} result
+    needs:
+      - prepare
+      - publish
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Report failure without duplicates
+        if: needs.prepare.result == 'failure' || needs.publish.result == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHANNEL: ${{ inputs.channel }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="automation: upstream ${CHANNEL} sync failed"
+          number="$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "\"$title\" in:title" \
+            --json number \
+            --jq '.[0].number // empty')"
+          body="The automated **${CHANNEL}** synchronization stopped safely. The previous published bundle is unchanged wherever possible.
+
+          Workflow run: ${RUN_URL}
+
+          Review the failed step and resolve the upstream conflict or build regression before retrying."
+          if [ -n "$number" ]; then
+            gh issue comment "$number" --repo "$GITHUB_REPOSITORY" --body "$body"
+          else
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$title" \
+              --label automation \
+              --label bug \
+              --body "$body"
+          fi
+
+      - name: Close an earlier failure after recovery
+        if: >-
+          needs.prepare.result == 'success' &&
+          (needs.publish.result == 'success' || needs.publish.result == 'skipped')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHANNEL: ${{ inputs.channel }}
+        run: |
+          title="automation: upstream ${CHANNEL} sync failed"
+          number="$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "\"$title\" in:title" \
+            --json number \
+            --jq '.[0].number // empty')"
+          if [ -n "$number" ]; then
+            gh issue comment "$number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body "The next automated synchronization completed successfully."
+            gh issue close "$number" --repo "$GITHUB_REPOSITORY" \
+              --reason completed
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ google-services.json
 
 # NPM modules
 node_modules/
+
+# Python tooling
+__pycache__/
+*.pyc

--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -1,0 +1,56 @@
+# Automatic upstream updates
+
+Dual VoT Patches tracks both Morphe release channels:
+
+| Dual VoT branch | Morphe branch | Manager channel | Release type |
+| --- | --- | --- | --- |
+| `main` | `main` | Stable | GitHub stable release |
+| `dev` | `dev` | Pre-release patches enabled | GitHub pre-release |
+
+The scheduled workflow checks both channels every six hours. It synchronizes
+exact Morphe release tags, not arbitrary unreleased branch commits.
+
+## Safety model
+
+Preparation and publication run as separate jobs:
+
+1. A read-only job fetches the upstream tag, performs the merge, builds the
+   Android patch bundle, regenerates metadata, and validates Dual VoT.
+2. The job exports an incremental Git bundle, release plan, and `.mpp`.
+3. A write-enabled job verifies their commit and SHA-256 values, publishes the
+   release, and advances the channel branch. It does not execute upstream code.
+
+An update is rejected when:
+
+- an unknown source file has a merge conflict;
+- Gradle compilation fails;
+- a required Dual VoT source file is missing;
+- either translation patch is absent from generated metadata;
+- the `.mpp` manifest, version, size, or checksum is inconsistent;
+- the remote branch changes while the candidate is building.
+
+On failure, the previous published bundle remains available and the workflow
+creates or updates a deduplicated `automation` issue with a link to its logs.
+
+## Versioning
+
+Automated versions keep the exact Morphe base and add a Dual VoT revision:
+
+```text
+Morphe 1.38.0       -> 1.38.0-dualvot.1
+Morphe 1.39.0-dev.2 -> 1.39.0-dev.2-dualvot.1
+```
+
+Users receive `main` by default. Morphe Manager checks `dev` as well when
+**Pre-release patches** is enabled for this source.
+
+## Manual operation
+
+Open **Actions → Sync Morphe upstream → Run workflow** and select:
+
+- `all` to check stable and pre-release sequentially;
+- `stable` to check only Morphe `main`;
+- `dev` to check only Morphe `dev`.
+
+The workflow uses the repository-scoped `GITHUB_TOKEN`; no personal access
+token or external bot account is required.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ When reporting a translation problem, include the YouTube URL, YouTube version,
 patch bundle version, translation engine, exact error text, and reproduction
 steps.
 
+## Update channels
+
+- The `main` branch follows stable Morphe Patches releases.
+- The `dev` branch follows Morphe Patches pre-releases.
+- Enable **Pre-release patches** for this source in Morphe Manager to receive
+  the `dev` channel. Leave it disabled for the stable channel.
+
+Both channels are checked automatically every six hours. An update is
+published only after the bundle compiles and the Dual VoT integration passes
+structural checks. Merge conflicts or failed builds stop publication and open
+an issue without replacing the previous working release. See
+[automatic upstream updates](AUTOMATION.md) for details.
+
 ## Credits and license
 
 The project is derived from


### PR DESCRIPTION
Adds a guarded GitHub Actions updater for both Morphe channels. Stable releases follow upstream main; prereleases follow upstream dev and remain available through the Manager pre-release toggle. The updater builds and validates candidates before publishing, preserves the last working release on failure, and opens a deduplicated automation issue when manual repair is needed. Local unit tests, full Android bundle build, stable/dev no-op simulations, and Git bundle transfer were verified.