### PR TITLE
Add configurable Yandex button countdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 1.37.0-dualvot.4-dev.1 (2026-07-27)
+
+### Configurable Yandex countdown
+
+* Add an animated countdown ring around the Yandex player button.
+* Allow the estimated time to appear inside or below the icon, or remain
+  hidden.
+* Add settings for ring visibility, color, and thickness.
+* Keep the button dimensions aligned with the other player controls when the
+  timer is shown below the icon.
+* Switch to an indeterminate animation when Yandex exceeds its estimate.
+* Show a short red animated signal for request and playback errors.
+
+### Status accuracy
+
+* Replace the misleading "check back later" message with a processing status.
+* Refresh the bottom sheet as soon as translated audio is prepared and starts
+  playing.
+
 ## 1.37.0-dualvot.3 (2026-07-26)
 
 ### Yandex translation reliability

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/voiceovertranslation/yandex/YandexVoiceOverTranslationPatch.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/voiceovertranslation/yandex/YandexVoiceOverTranslationPatch.java
@@ -86,6 +86,7 @@ public class YandexVoiceOverTranslationPatch {
 
     private static final long PAUSE_DETECTION_TIMEOUT_MS = 1500;
     private static final long PROXY_PREPARE_TIMEOUT_MS = 15000;
+    private static final long ERROR_INDICATOR_DURATION_MS = 1800;
     private static final String PROXY_USER_AGENT =
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
             "(KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36";
@@ -108,6 +109,9 @@ public class YandexVoiceOverTranslationPatch {
     private static Runnable proxyPrepareTimeoutRunnable = () -> {};
     private static final Set<Runnable> translationStateChangeCallbacks =
             new CopyOnWriteArraySet<>();
+    private static volatile long translationErrorUntilMs = -1;
+    private static final Runnable errorIndicatorExpired =
+            YandexVoiceOverTranslationPatch::notifyTranslationStateChanged;
 
     public static void addOnTranslationStateChangeCallback(Runnable callback) {
         if (callback != null) translationStateChangeCallbacks.add(callback);
@@ -117,6 +121,19 @@ public class YandexVoiceOverTranslationPatch {
         for (Runnable callback : translationStateChangeCallbacks) {
             Utils.runOnMainThread(callback);
         }
+    }
+
+    private static void showTranslationErrorToast(String message) {
+        translationErrorUntilMs =
+                SystemClock.elapsedRealtime() + ERROR_INDICATOR_DURATION_MS;
+        notifyTranslationStateChanged();
+        mainHandler.removeCallbacks(errorIndicatorExpired);
+        mainHandler.postDelayed(errorIndicatorExpired, ERROR_INDICATOR_DURATION_MS);
+        showToastShort(message);
+    }
+
+    public static boolean isTranslationErrorVisible() {
+        return SystemClock.elapsedRealtime() < translationErrorUntilMs;
     }
 
     /** Runs a Runnable on the main thread only if translation generation hasn't changed. */
@@ -160,7 +177,16 @@ public class YandexVoiceOverTranslationPatch {
     public static int getWaitingTimeSeconds() {
         if (waitingTimeSeconds < 0 || waitingDeadlineMs < 0) return -1;
         final long remainingMs = waitingDeadlineMs - SystemClock.elapsedRealtime();
-        return (int) Math.max(1, (remainingMs + 999L) / 1000L);
+        return (int) Math.max(0, (remainingMs + 999L) / 1000L);
+    }
+
+    public static float getWaitingProgressFraction() {
+        if (waitingTimeSeconds <= 0 || waitingDeadlineMs < 0) return -1.0f;
+        final long remainingMs = waitingDeadlineMs - SystemClock.elapsedRealtime();
+        return Math.max(0.0f, Math.min(
+                1.0f,
+                remainingMs / (waitingTimeSeconds * 1000.0f)
+        ));
     }
 
     public static String getTranslationRequestStatusText() {
@@ -176,13 +202,13 @@ public class YandexVoiceOverTranslationPatch {
             );
         }
         int seconds = getWaitingTimeSeconds();
-        return seconds >= 0
+        return seconds > 0
                 ? str("dualvot_yandex_stream_waiting", formatRemainingTime(seconds))
                 : str("dualvot_yandex_stream_waiting_status");
     }
 
     public static boolean isWaitingCountdownActive() {
-        return translationStarting && getWaitingTimeSeconds() >= 0;
+        return translationStarting && getWaitingTimeSeconds() > 0;
     }
 
     private static void setAudioUploadProgress(long generation, int part, int totalParts) {
@@ -272,17 +298,17 @@ public class YandexVoiceOverTranslationPatch {
         }
 
         if (pendingIsLive) {
-            showToastShort(str("dualvot_yandex_unavailable_live"));
+            showTranslationErrorToast(str("dualvot_yandex_unavailable_live"));
             return;
         }
         if (pendingVideoLength > 4 * 60 * 60 * 1000L) {
-            showToastShort(str("dualvot_yandex_unavailable_too_long"));
+            showTranslationErrorToast(str("dualvot_yandex_unavailable_too_long"));
             return;
         }
         String sourceLang = normalizeLanguageCode(Settings.DUAL_VOT_YANDEX_SOURCE_LANGUAGE.get());
         String targetLang = normalizeLanguageCode(Settings.DUAL_VOT_YANDEX_TARGET_LANGUAGE.get());
         if (!sourceLang.isEmpty() && !"auto".equalsIgnoreCase(sourceLang) && sourceLang.equals(targetLang)) {
-            showToastShort(str("dualvot_yandex_unavailable_same_language"));
+            showTranslationErrorToast(str("dualvot_yandex_unavailable_same_language"));
             return;
         }
         if (pendingVideoId == null || pendingVideoId.isEmpty()) return;
@@ -489,7 +515,7 @@ public class YandexVoiceOverTranslationPatch {
                     setWaitingTimeSeconds(-1);
                     translationStarting = false;
                     refreshOriginalAudioVolume();
-                    showToastShort(str("dualvot_yandex_playback_error"));
+                    showTranslationErrorToast(str("dualvot_yandex_playback_error"));
                 });
                 return;
             }
@@ -508,7 +534,7 @@ public class YandexVoiceOverTranslationPatch {
                         setWaitingTimeSeconds(-1);
                         translationStarting = false;
                         refreshOriginalAudioVolume();
-                        showToastShort(str("dualvot_yandex_playback_error"));
+                        showTranslationErrorToast(str("dualvot_yandex_playback_error"));
                     });
                 }
             } else if (status == YandexVotApiClient.STATUS_FAILED) {
@@ -526,7 +552,7 @@ public class YandexVoiceOverTranslationPatch {
                     setWaitingTimeSeconds(-1);
                     translationStarting = false;
                     refreshOriginalAudioVolume();
-                    showToastShort(str("dualvot_yandex_playback_error"));
+                    showTranslationErrorToast(str("dualvot_yandex_playback_error"));
                 });
             } else if (status == YandexVotApiClient.STATUS_SESSION_REQUIRED) {
                 if (useLiveVoices) {
@@ -555,7 +581,7 @@ public class YandexVoiceOverTranslationPatch {
                     setWaitingTimeSeconds(-1);
                     translationStarting = false;
                     refreshOriginalAudioVolume();
-                    showToastShort(str("dualvot_yandex_playback_error"));
+                    showTranslationErrorToast(str("dualvot_yandex_playback_error"));
                 });
             } else if (status == YandexVotApiClient.STATUS_AUDIO_REQUESTED) {
                 String translationId = result.translationId();
@@ -586,7 +612,7 @@ public class YandexVoiceOverTranslationPatch {
             runOnUiIfCurrentGen(generation, () -> {
                 translationStarting = false;
                 refreshOriginalAudioVolume();
-                showToastShort(str("dualvot_yandex_playback_error"));
+                showTranslationErrorToast(str("dualvot_yandex_playback_error"));
             });
         } finally {
             isTranslating.set(false);
@@ -629,7 +655,7 @@ public class YandexVoiceOverTranslationPatch {
                     runOnUiIfCurrentGen(generation, () -> {
                         translationStarting = false;
                         refreshOriginalAudioVolume();
-                        showToastShort(str("dualvot_yandex_playback_error"));
+                        showTranslationErrorToast(str("dualvot_yandex_playback_error"));
                     });
                 }
                 return;
@@ -643,7 +669,7 @@ public class YandexVoiceOverTranslationPatch {
                 runOnUiIfCurrentGen(generation, () -> {
                     translationStarting = false;
                     refreshOriginalAudioVolume();
-                    showToastShort(str("dualvot_yandex_playback_error"));
+                    showTranslationErrorToast(str("dualvot_yandex_playback_error"));
                 });
                 return;
             } else if (status == YandexVotApiClient.STATUS_FAILED) {
@@ -658,7 +684,7 @@ public class YandexVoiceOverTranslationPatch {
                 runOnUiIfCurrentGen(generation, () -> {
                     translationStarting = false;
                     refreshOriginalAudioVolume();
-                    showToastShort(str("dualvot_yandex_playback_error"));
+                    showTranslationErrorToast(str("dualvot_yandex_playback_error"));
                 });
                 return;
             } else if (status == YandexVotApiClient.STATUS_SESSION_REQUIRED) {
@@ -682,7 +708,7 @@ public class YandexVoiceOverTranslationPatch {
                 runOnUiIfCurrentGen(generation, () -> {
                     translationStarting = false;
                     refreshOriginalAudioVolume();
-                    showToastShort(str("dualvot_yandex_playback_error"));
+                    showTranslationErrorToast(str("dualvot_yandex_playback_error"));
                 });
                 return;
             } else if (status == YandexVotApiClient.STATUS_AUDIO_REQUESTED) {
@@ -721,7 +747,7 @@ public class YandexVoiceOverTranslationPatch {
                 runOnUiIfCurrentGen(generation, () -> {
                     translationStarting = false;
                     refreshOriginalAudioVolume();
-                    showToastShort(str("dualvot_yandex_playback_error"));
+                    showTranslationErrorToast(str("dualvot_yandex_playback_error"));
                 });
             }
         }
@@ -801,7 +827,7 @@ public class YandexVoiceOverTranslationPatch {
                 } else {
                     translationStarting = false;
                     refreshOriginalAudioVolume();
-                    showToastShort(str("dualvot_yandex_playback_error"));
+                    showTranslationErrorToast(str("dualvot_yandex_playback_error"));
                 }
                 return;
             }
@@ -816,7 +842,7 @@ public class YandexVoiceOverTranslationPatch {
                     } else {
                         translationStarting = false;
                         refreshOriginalAudioVolume();
-                        showToastShort(str("dualvot_yandex_playback_error"));
+                        showTranslationErrorToast(str("dualvot_yandex_playback_error"));
                     }
                 });
             });
@@ -903,6 +929,7 @@ public class YandexVoiceOverTranslationPatch {
             mp.setDataSource(filePath);
             mp.setOnPreparedListener(player -> Utils.runOnMainThread(() -> {
                 translationStarting = false;
+                clearAudioUploadProgress();
                 float vol = Settings.DUAL_VOT_YANDEX_TRANSLATION_VOLUME.get() / 100.0f;
                 player.setVolume(vol, vol);
                 long videoTime = VideoInformation.getVideoTime();
@@ -917,6 +944,7 @@ public class YandexVoiceOverTranslationPatch {
                 // MediaPlayer instances. Re-apply the selected Yandex ducking level
                 // once the translated track is actually ready.
                 refreshOriginalAudioVolume();
+                notifyTranslationStateChanged();
             }));
             mp.setOnErrorListener((p, what, extra) -> {
                 Logger.printDebug(() -> "VOT MediaPlayer error: what=" + what + " extra=" + extra);
@@ -924,7 +952,7 @@ public class YandexVoiceOverTranslationPatch {
                     stopAudioPlayback();
                     translationStarting = false;
                     refreshOriginalAudioVolume();
-                    showToastShort(str("dualvot_yandex_playback_error"));
+                    showTranslationErrorToast(str("dualvot_yandex_playback_error"));
                 });
                 return true;
             });
@@ -938,7 +966,7 @@ public class YandexVoiceOverTranslationPatch {
             deleteTempProxyFile();
             translationStarting = false;
             refreshOriginalAudioVolume();
-            showToastShort(str("dualvot_yandex_playback_error"));
+            showTranslationErrorToast(str("dualvot_yandex_playback_error"));
         }
     }
 
@@ -968,6 +996,7 @@ public class YandexVoiceOverTranslationPatch {
             final String fallback = fallbackUrl;
             mp.setOnPreparedListener(player -> Utils.runOnMainThread(() -> {
                 translationStarting = false;
+                clearAudioUploadProgress();
                 mainHandler.removeCallbacks(proxyPrepareTimeoutRunnable);
                 float vol = Settings.DUAL_VOT_YANDEX_TRANSLATION_VOLUME.get() / 100.0f;
                 player.setVolume(vol, vol);
@@ -981,6 +1010,7 @@ public class YandexVoiceOverTranslationPatch {
                     isPaused = true;
                 }
                 refreshOriginalAudioVolume();
+                notifyTranslationStateChanged();
             }));
             mp.setOnErrorListener((p, what, extra) -> {
                 Logger.printDebug(() -> "VOT MediaPlayer error: what=" + what + " extra=" + extra + " url=" + audioUrl);
@@ -991,7 +1021,7 @@ public class YandexVoiceOverTranslationPatch {
                     } else {
                         translationStarting = false;
                         refreshOriginalAudioVolume();
-                        showToastShort(str("dualvot_yandex_playback_error"));
+                        showTranslationErrorToast(str("dualvot_yandex_playback_error"));
                     }
                 });
                 return true;
@@ -1021,7 +1051,7 @@ public class YandexVoiceOverTranslationPatch {
                 } else {
                     translationStarting = false;
                     refreshOriginalAudioVolume();
-                    showToastShort(str("dualvot_yandex_playback_error"));
+                    showTranslationErrorToast(str("dualvot_yandex_playback_error"));
                 }
             });
         }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/settings/Settings.java
@@ -550,6 +550,10 @@ public class Settings extends SharedYouTubeSettings {
     // Dual VoT - Yandex engine. Keep every key independent from the official
     // caption-plus-TTS engine so users can enable both buttons safely.
     public static final BooleanSetting DUAL_VOT_YANDEX_ENABLED = new BooleanSetting("dualvot_yandex_enabled", FALSE);
+    public static final StringSetting DUAL_VOT_YANDEX_TIMER_POSITION = new StringSetting("dualvot_yandex_timer_position", "inside", false, parent(DUAL_VOT_YANDEX_ENABLED));
+    public static final BooleanSetting DUAL_VOT_YANDEX_PROGRESS_RING_ENABLED = new BooleanSetting("dualvot_yandex_progress_ring_enabled", TRUE, false, parent(DUAL_VOT_YANDEX_ENABLED));
+    public static final StringSetting DUAL_VOT_YANDEX_PROGRESS_RING_COLOR = new StringSetting("dualvot_yandex_progress_ring_color", "#FFC107", false, parent(DUAL_VOT_YANDEX_PROGRESS_RING_ENABLED));
+    public static final IntegerSetting DUAL_VOT_YANDEX_PROGRESS_RING_THICKNESS = new IntegerSetting("dualvot_yandex_progress_ring_thickness", 2, false, parent(DUAL_VOT_YANDEX_PROGRESS_RING_ENABLED));
     public static final StringSetting DUAL_VOT_YANDEX_SOURCE_LANGUAGE = new StringSetting("dualvot_yandex_source_language", "auto", false, parent(DUAL_VOT_YANDEX_ENABLED));
     public static final StringSetting DUAL_VOT_YANDEX_TARGET_LANGUAGE = new StringSetting("dualvot_yandex_target_language", "ru", false, parent(DUAL_VOT_YANDEX_ENABLED));
     public static final IntegerSetting DUAL_VOT_YANDEX_TRANSLATION_VOLUME = new IntegerSetting("dualvot_yandex_translation_volume", 100, false, parent(DUAL_VOT_YANDEX_ENABLED));
@@ -802,6 +806,8 @@ public class Settings extends SharedYouTubeSettings {
                 0, 100, 1, "%"));
         SeekBarPreference.register(new SeekBarConfig(DUAL_VOT_YANDEX_TRANSLATION_VOLUME,
                 0, 100, 1, "%"));
+        SeekBarPreference.register(new SeekBarConfig(DUAL_VOT_YANDEX_PROGRESS_RING_THICKNESS,
+                1, 6, 1, "dp"));
         SeekBarPreference.register(new SeekBarConfig(VOT_MAX_SPEECH_RATE,
                 10, 25, 1, "x", 10));
     }

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/YandexVoiceOverTranslationButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/YandexVoiceOverTranslationButton.java
@@ -45,6 +45,17 @@
 
 package app.morphe.extension.youtube.videoplayer;
 
+import static app.morphe.extension.shared.StringRef.str;
+
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.ColorFilter;
+import android.graphics.Paint;
+import android.graphics.PixelFormat;
+import android.graphics.RectF;
+import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
+import android.os.SystemClock;
 import android.view.View;
 import android.widget.ImageView;
 
@@ -54,17 +65,26 @@ import java.lang.ref.WeakReference;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
-import app.morphe.extension.youtube.patches.voiceovertranslation.yandex.YandexVotBottomSheet;
 import app.morphe.extension.youtube.patches.voiceovertranslation.VoiceOverTranslationCoordinator;
+import app.morphe.extension.youtube.patches.voiceovertranslation.yandex.YandexVoiceOverTranslationPatch;
+import app.morphe.extension.youtube.patches.voiceovertranslation.yandex.YandexVotBottomSheet;
 import app.morphe.extension.youtube.settings.Settings;
 
 @SuppressWarnings("unused")
 public final class YandexVoiceOverTranslationButton {
+    private static final long DETERMINATE_FRAME_DELAY_MS = 250;
+    private static final long INDETERMINATE_FRAME_DELAY_MS = 50;
+    private static final int ERROR_COLOR = 0xFFFF3B30;
+
     private static final Runnable STATE_REFRESH_CALLBACK =
+            YandexVoiceOverTranslationButton::refreshActivatedState;
+    private static final Runnable PROGRESS_TICK =
             YandexVoiceOverTranslationButton::refreshActivatedState;
 
     @Nullable
     private static WeakReference<ImageView> overlayButtonRef;
+    @Nullable
+    private static WeakReference<CountdownDrawable> countdownDrawableRef;
 
     public static void initializeButton(View controlsView) {
         try {
@@ -80,6 +100,14 @@ public final class YandexVoiceOverTranslationButton {
                         return true;
                     });
             overlayButtonRef = button != null ? new WeakReference<>(button) : null;
+            if (button != null) {
+                CountdownDrawable drawable = new CountdownDrawable(button);
+                countdownDrawableRef = new WeakReference<>(drawable);
+                button.setForeground(drawable);
+                button.post(STATE_REFRESH_CALLBACK);
+            } else {
+                countdownDrawableRef = null;
+            }
             refreshActivatedState();
         } catch (Exception ex) {
             Logger.printException(() -> "YandexVoiceOverTranslationButton initializeButton failure", ex);
@@ -95,9 +123,230 @@ public final class YandexVoiceOverTranslationButton {
             ImageView overlay = ref != null ? ref.get() : null;
             if (overlay != null) {
                 overlay.setImageAlpha(alpha);
+                overlay.removeCallbacks(PROGRESS_TICK);
+
+                boolean waiting = YandexVoiceOverTranslationPatch.translationStarting;
+                boolean error = YandexVoiceOverTranslationPatch.isTranslationErrorVisible();
+                int seconds = YandexVoiceOverTranslationPatch.getWaitingTimeSeconds();
+                float progress = YandexVoiceOverTranslationPatch.getWaitingProgressFraction();
+                String timerPosition = Settings.DUAL_VOT_YANDEX_TIMER_POSITION.get();
+                boolean showTimer = waiting && !"hidden".equals(timerPosition);
+
+                updateIconPadding(overlay, waiting && "below".equals(timerPosition));
+
+                WeakReference<CountdownDrawable> drawableRef = countdownDrawableRef;
+                CountdownDrawable drawable = drawableRef != null ? drawableRef.get() : null;
+                if (drawable != null) {
+                    drawable.update(
+                            waiting,
+                            error,
+                            showTimer,
+                            "below".equals(timerPosition),
+                            Settings.DUAL_VOT_YANDEX_PROGRESS_RING_ENABLED.get(),
+                            Settings.DUAL_VOT_YANDEX_PROGRESS_RING_COLOR.get(),
+                            Settings.DUAL_VOT_YANDEX_PROGRESS_RING_THICKNESS.get(),
+                            seconds,
+                            progress
+                    );
+                }
+
+                if (waiting || error) {
+                    boolean indeterminate = error || seconds <= 0 || progress < 0.0f;
+                    overlay.postDelayed(
+                            PROGRESS_TICK,
+                            indeterminate
+                                    ? INDETERMINATE_FRAME_DELAY_MS
+                                    : DETERMINATE_FRAME_DELAY_MS
+                    );
+                }
             }
         } catch (Exception ex) {
             Logger.printException(() -> "refreshActivatedState failure", ex);
+        }
+    }
+
+    private static void updateIconPadding(ImageView button, boolean timerBelow) {
+        int size = Math.min(button.getWidth(), button.getHeight());
+        int side = timerBelow ? Math.round(size * 0.12f) : 0;
+        int top = timerBelow ? Math.round(size * 0.04f) : 0;
+        int bottom = timerBelow ? Math.round(size * 0.25f) : 0;
+        if (button.getPaddingLeft() != side
+                || button.getPaddingTop() != top
+                || button.getPaddingRight() != side
+                || button.getPaddingBottom() != bottom) {
+            button.setPadding(side, top, side, bottom);
+        }
+    }
+
+    private static final class CountdownDrawable extends Drawable {
+        private final Paint ringPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        private final Paint textPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        private final Paint textBackgroundPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        private final RectF ringBounds = new RectF();
+        private final RectF textBackgroundBounds = new RectF();
+        private final float density;
+
+        private boolean waiting;
+        private boolean error;
+        private boolean showTimer;
+        private boolean timerBelow;
+        private boolean showRing;
+        private int ringColor = 0xFFFFC107;
+        private float ringThicknessPx;
+        private int remainingSeconds = -1;
+        private float progress = -1.0f;
+
+        CountdownDrawable(ImageView owner) {
+            density = owner.getResources().getDisplayMetrics().density;
+            ringPaint.setStyle(Paint.Style.STROKE);
+            ringPaint.setStrokeCap(Paint.Cap.ROUND);
+
+            textPaint.setColor(Color.WHITE);
+            textPaint.setTextAlign(Paint.Align.CENTER);
+            textPaint.setTypeface(Typeface.create("sans-serif-condensed", Typeface.BOLD));
+
+            textBackgroundPaint.setColor(0xB3000000);
+            textBackgroundPaint.setStyle(Paint.Style.FILL);
+        }
+
+        void update(
+                boolean waiting,
+                boolean error,
+                boolean showTimer,
+                boolean timerBelow,
+                boolean showRing,
+                String configuredColor,
+                int configuredThicknessDp,
+                int remainingSeconds,
+                float progress
+        ) {
+            this.waiting = waiting;
+            this.error = error;
+            this.showTimer = showTimer;
+            this.timerBelow = timerBelow;
+            this.showRing = showRing;
+            this.ringColor = parseColor(configuredColor);
+            this.ringThicknessPx = Math.max(1.0f, configuredThicknessDp * density);
+            this.remainingSeconds = remainingSeconds;
+            this.progress = progress;
+            invalidateSelf();
+        }
+
+        @Override
+        public void draw(Canvas canvas) {
+            if (!waiting && !error) return;
+
+            if (showRing || error) {
+                drawRing(canvas);
+            }
+            if (showTimer && waiting) {
+                drawTimer(canvas);
+            }
+        }
+
+        private void drawRing(Canvas canvas) {
+            float inset = ringThicknessPx / 2.0f + density;
+            ringBounds.set(
+                    getBounds().left + inset,
+                    getBounds().top + inset,
+                    getBounds().right - inset,
+                    getBounds().bottom - inset
+            );
+            ringPaint.setStrokeWidth(ringThicknessPx);
+
+            if (error) {
+                float pulse = (float) ((Math.sin(SystemClock.uptimeMillis() / 90.0) + 1.0) / 2.0);
+                ringPaint.setColor(withAlpha(ERROR_COLOR, Math.round(120 + pulse * 135)));
+                float start = (SystemClock.uptimeMillis() / 3.0f) % 360.0f - 90.0f;
+                canvas.drawArc(ringBounds, start, 115.0f, false, ringPaint);
+                return;
+            }
+
+            ringPaint.setColor(withAlpha(ringColor, 48));
+            canvas.drawArc(ringBounds, -90.0f, 360.0f, false, ringPaint);
+
+            ringPaint.setColor(ringColor);
+            if (remainingSeconds > 0 && progress >= 0.0f) {
+                canvas.drawArc(
+                        ringBounds,
+                        -90.0f,
+                        360.0f * Math.max(0.0f, Math.min(1.0f, progress)),
+                        false,
+                        ringPaint
+                );
+            } else {
+                float start = (SystemClock.uptimeMillis() / 3.0f) % 360.0f - 90.0f;
+                canvas.drawArc(ringBounds, start, 100.0f, false, ringPaint);
+            }
+        }
+
+        private void drawTimer(Canvas canvas) {
+            String text = formatTimerText(remainingSeconds);
+            float width = getBounds().width();
+            float height = getBounds().height();
+            float textSize = Math.min(width, height) * (timerBelow ? 0.18f : 0.24f);
+            textPaint.setTextSize(Math.max(8.0f * density, textSize));
+
+            Paint.FontMetrics metrics = textPaint.getFontMetrics();
+            float centerX = getBounds().exactCenterX();
+            float centerY = timerBelow
+                    ? getBounds().bottom - Math.max(6.0f * density, height * 0.13f)
+                    : getBounds().exactCenterY();
+            float baseline = centerY - (metrics.ascent + metrics.descent) / 2.0f;
+            float textWidth = textPaint.measureText(text);
+            float horizontalPadding = 3.0f * density;
+            float verticalPadding = 1.0f * density;
+
+            textBackgroundBounds.set(
+                    centerX - textWidth / 2.0f - horizontalPadding,
+                    baseline + metrics.ascent - verticalPadding,
+                    centerX + textWidth / 2.0f + horizontalPadding,
+                    baseline + metrics.descent + verticalPadding
+            );
+            float radius = 4.0f * density;
+            canvas.drawRoundRect(textBackgroundBounds, radius, radius, textBackgroundPaint);
+            canvas.drawText(text, centerX, baseline, textPaint);
+        }
+
+        private static String formatTimerText(int seconds) {
+            if (seconds <= 0) return "…";
+            if (seconds >= 60) {
+                int minutes = (seconds + 59) / 60;
+                return str("dualvot_yandex_button_time_minutes", minutes);
+            }
+            return str("dualvot_yandex_button_time_seconds", seconds);
+        }
+
+        private static int parseColor(String value) {
+            try {
+                return Color.parseColor(value);
+            } catch (Exception ignored) {
+                return 0xFFFFC107;
+            }
+        }
+
+        private static int withAlpha(int color, int alpha) {
+            return (color & 0x00FFFFFF) | (Math.max(0, Math.min(255, alpha)) << 24);
+        }
+
+        @Override
+        public void setAlpha(int alpha) {
+            ringPaint.setAlpha(alpha);
+            textPaint.setAlpha(alpha);
+            invalidateSelf();
+        }
+
+        @Override
+        public void setColorFilter(@Nullable ColorFilter colorFilter) {
+            ringPaint.setColorFilter(colorFilter);
+            textPaint.setColorFilter(colorFilter);
+            invalidateSelf();
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public int getOpacity() {
+            return PixelFormat.TRANSLUCENT;
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.37.0-dualvot.3
+version = 1.37.0-dualvot.4-dev.1

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-07-26T19:09:17",
-  "description": "## Dual VoT Patches 1.37.0-dualvot.3\n\n### Yandex translation reliability\n\n- Resolves a dedicated low-bitrate YouTube audio stream when no usable cached format is available.\n- Validates downloaded byte ranges before uploading them to Yandex.\n- Keeps original audio at full volume while a new translation is generated, then applies the configured level when translated playback begins.\n\n### Included base\n\n- Based on stable Morphe Patches 1.37.0.\n- Includes both the built-in Google/other translation and Yandex translation with mutually exclusive player controls.",
-  "download_url": "https://github.com/sashade8-ship-it/dual-vot-patches/releases/download/v1.37.0-dualvot.3/patches-1.37.0-dualvot.3.mpp",
+  "created_at": "2026-07-27T13:16:09",
+  "description": "## Dual VoT Patches 1.37.0-dualvot.4-dev.1\n\n### Configurable Yandex countdown\n\n- Adds an animated progress ring to the Yandex player button.\n- Shows the estimated remaining time inside or below the icon, or hides the text.\n- Adds settings for ring visibility, color, and thickness.\n- Switches to an indeterminate animation when Yandex exceeds its estimate.\n- Shows a short red animated signal for request or playback errors.\n- Updates the bottom-sheet status immediately when translated audio starts.\n\n### Included base\n\n- Based on stable Morphe Patches 1.37.0.\n- Test pre-release; enable pre-release patches for this source in Morphe Manager.",
+  "download_url": "https://github.com/sashade8-ship-it/dual-vot-patches/releases/download/v1.37.0-dualvot.4-dev.1/patches-1.37.0-dualvot.4-dev.1.mpp",
   "signature_download_url": "",
-  "version": "1.37.0-dualvot.3"
+  "version": "1.37.0-dualvot.4-dev.1"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.37.0-dualvot.3",
+  "version": "1.37.0-dualvot.4-dev.1",
   "patches": [
     {
       "name": "Add to queue",

--- a/patches/src/main/kotlin/app/morphe/patches/youtube/video/voiceovertranslation/YandexVoiceOverTranslationPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/youtube/video/voiceovertranslation/YandexVoiceOverTranslationPatch.kt
@@ -63,6 +63,22 @@ val yandexVoiceOverTranslationPatch = bytecodePatch(
                 preferences = setOf(
                     SwitchPreference("dualvot_yandex_enabled"),
                     ListPreference(
+                        key = "dualvot_yandex_timer_position",
+                        entriesKey = "dualvot_yandex_timer_position_entries",
+                        entryValuesKey = "dualvot_yandex_timer_position_entry_values",
+                    ),
+                    SwitchPreference("dualvot_yandex_progress_ring_enabled"),
+                    NonInteractivePreference(
+                        key = "dualvot_yandex_progress_ring_color",
+                        tag = "app.morphe.extension.shared.settings.preference.ColorPickerPreference",
+                        selectable = true,
+                    ),
+                    NonInteractivePreference(
+                        key = "dualvot_yandex_progress_ring_thickness",
+                        tag = "app.morphe.extension.shared.settings.preference.SeekBarPreference",
+                        selectable = true,
+                    ),
+                    ListPreference(
                         key = "dualvot_yandex_source_language",
                         entriesKey = "dualvot_yandex_source_language_entries",
                         entryValuesKey = "dualvot_yandex_source_language_entry_values",

--- a/patches/src/main/resources/addresources/values-ru-rRU/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values-ru-rRU/youtube/strings.xml
@@ -1112,6 +1112,21 @@ Second \"item\" text"</string>
     <string name="dualvot_yandex_enabled_summary">Перевод от Яндекса</string>
     <string name="dualvot_yandex_enabled_summary_on">Яндекс-перевод включён</string>
     <string name="dualvot_yandex_enabled_summary_off">Яндекс-перевод отключён</string>
+    <string name="dualvot_yandex_timer_position_title">Расположение таймера</string>
+    <string name="dualvot_yandex_timer_position_summary">Выберите, где показывать примерное оставшееся время на кнопке плеера</string>
+    <string-array name="dualvot_yandex_timer_position_entries">
+        <item>Внутри иконки</item>
+        <item>Под иконкой</item>
+        <item>Не показывать</item>
+    </string-array>
+    <string name="dualvot_yandex_progress_ring_enabled_title">Показывать кольцо прогресса</string>
+    <string name="dualvot_yandex_progress_ring_enabled_summary">Отображать ход подготовки перевода вокруг кнопки Яндекса</string>
+    <string name="dualvot_yandex_progress_ring_color_title">Цвет кольца прогресса</string>
+    <string name="dualvot_yandex_progress_ring_color_summary">Цвет кольца во время подготовки перевода</string>
+    <string name="dualvot_yandex_progress_ring_thickness_title">Толщина кольца прогресса</string>
+    <string name="dualvot_yandex_progress_ring_thickness_summary">Толщина полосы вокруг кнопки плеера</string>
+    <string name="dualvot_yandex_button_time_minutes">%sм</string>
+    <string name="dualvot_yandex_button_time_seconds">%sс</string>
     <string name="dualvot_yandex_source_language_title">Язык источника</string>
     <string name="dualvot_yandex_source_language_summary">Выберите язык аудио видео</string>
     <string name="dualvot_yandex_target_language_title">Язык перевода</string>
@@ -1140,7 +1155,7 @@ Second \"item\" text"</string>
     <string name="dualvot_yandex_unavailable_too_long">Видео слишком длинное для перевода (макс. 4 часа)</string>
     <string name="dualvot_yandex_unavailable_same_language">Аудио видео уже на языке перевода</string>
     <string name="dualvot_yandex_stream_waiting">Ожидание… ~%s</string>
-    <string name="dualvot_yandex_stream_waiting_status">Перевод запрошен, вернитесь позже</string>
+    <string name="dualvot_yandex_stream_waiting_status">Перевод ещё обрабатывается…</string>
     <string name="dualvot_yandex_stream_not_ready">Перевод ещё не готов. Используйте кнопку для включения.</string>
     <string name="dualvot_yandex_stream_requesting">Запрос перевода для потока…</string>
     <string name="dualvot_yandex_stream_ready">Перевод готов, воспроизведение</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1239,6 +1239,26 @@ Limitation: Reverts to old style 'More videos' overlay"</string>
     <string name="dualvot_yandex_enabled_summary">Translation by Yandex</string>
     <string name="dualvot_yandex_enabled_summary_on">Yandex translation is enabled</string>
     <string name="dualvot_yandex_enabled_summary_off">Yandex translation is disabled</string>
+    <string name="dualvot_yandex_timer_position_title">Countdown placement</string>
+    <string name="dualvot_yandex_timer_position_summary">Choose where the estimated remaining time appears on the player button</string>
+    <string-array name="dualvot_yandex_timer_position_entries">
+        <item>Inside the icon</item>
+        <item>Below the icon</item>
+        <item>Hidden</item>
+    </string-array>
+    <string-array name="dualvot_yandex_timer_position_entry_values" translatable="false">
+        <item>inside</item>
+        <item>below</item>
+        <item>hidden</item>
+    </string-array>
+    <string name="dualvot_yandex_progress_ring_enabled_title">Show progress ring</string>
+    <string name="dualvot_yandex_progress_ring_enabled_summary">Display translation progress around the Yandex player button</string>
+    <string name="dualvot_yandex_progress_ring_color_title">Progress ring color</string>
+    <string name="dualvot_yandex_progress_ring_color_summary">Color used while a translation is being prepared</string>
+    <string name="dualvot_yandex_progress_ring_thickness_title">Progress ring thickness</string>
+    <string name="dualvot_yandex_progress_ring_thickness_summary">Thickness of the progress ring around the player button</string>
+    <string name="dualvot_yandex_button_time_minutes">%sm</string>
+    <string name="dualvot_yandex_button_time_seconds">%ss</string>
     <string name="dualvot_yandex_source_language_title">Source language</string>
     <string name="dualvot_yandex_source_language_summary">Select the language of the video audio</string>
     <string name="dualvot_yandex_target_language_title">Target language</string>
@@ -1268,7 +1288,7 @@ Limitation: Reverts to old style 'More videos' overlay"</string>
     <string name="dualvot_yandex_unavailable_too_long">Video is too long for translation (max 4 hours)</string>
     <string name="dualvot_yandex_unavailable_same_language">Video audio is already in the target language</string>
     <string name="dualvot_yandex_stream_waiting">Waiting… ~%s</string>
-    <string name="dualvot_yandex_stream_waiting_status">Translation requested, check back later</string>
+    <string name="dualvot_yandex_stream_waiting_status">Translation is still being processed…</string>
     <string name="dualvot_yandex_stream_not_ready">Translation not ready. Use the button to enable when ready.</string>
     <string name="dualvot_yandex_stream_requesting">Requesting translation for stream…</string>
     <string name="dualvot_yandex_stream_ready">Translation ready, playing</string>


### PR DESCRIPTION
## What changed

- adds a circular countdown/progress indicator around the Yandex player button;
- lets users place the compact time inside or below the icon, or hide it;
- adds settings for ring visibility, color, and thickness;
- switches to an indeterminate animation when Yandex exceeds its estimate;
- shows a short red animated signal for request and playback errors;
- refreshes the bottom-sheet status as soon as translated audio is actually prepared.

## Why

The previous UI exposed the estimate only in the long-press sheet and could continue showing “check back later” after translated audio had already started. The button now reflects the engine's actual state while keeping its original dimensions and alignment.

## Validation

- `:patches:buildAndroid generatePatchesList` completed successfully;
- final `:patches:buildAndroid` for `1.37.0-dualvot.4-dev.1` completed successfully;
- the `.mpp` manifest reports `Dual VoT Patches` and the expected prerelease version.

This targets `dev` so it can be tested through Morphe Manager's pre-release channel before promotion to stable.