### PR TITLE
fix: package Yandex countdown resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.37.0-dev.1-dualvot.4 (2026-07-27)
+
+### Packaging fix
+
+* Move the countdown placement arrays to `arrays.xml` and keep their labels as
+  localized string resources so Arsclib can encode the patched APK.
+* Use a Manager-compatible pre-release version order so the `dev` bundle is
+  selected over `1.37.0-dualvot.3` when pre-release patches are enabled.
+
 ## 1.37.0-dualvot.4-dev.1 (2026-07-27)
 
 ### Configurable Yandex countdown

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.37.0-dualvot.4-dev.1
+version = 1.37.0-dev.1-dualvot.4

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-07-27T13:16:09",
-  "description": "## Dual VoT Patches 1.37.0-dualvot.4-dev.1\n\n### Configurable Yandex countdown\n\n- Adds an animated progress ring to the Yandex player button.\n- Shows the estimated remaining time inside or below the icon, or hides the text.\n- Adds settings for ring visibility, color, and thickness.\n- Switches to an indeterminate animation when Yandex exceeds its estimate.\n- Shows a short red animated signal for request or playback errors.\n- Updates the bottom-sheet status immediately when translated audio starts.\n\n### Included base\n\n- Based on stable Morphe Patches 1.37.0.\n- Test pre-release; enable pre-release patches for this source in Morphe Manager.",
-  "download_url": "https://github.com/sashade8-ship-it/dual-vot-patches/releases/download/v1.37.0-dualvot.4-dev.1/patches-1.37.0-dualvot.4-dev.1.mpp",
+  "created_at": "2026-07-27T13:36:44",
+  "description": "## Dual VoT Patches 1.37.0-dev.1-dualvot.4\n\n### Configurable Yandex countdown\n\n- Adds an animated progress ring to the Yandex player button.\n- Shows the estimated remaining time inside or below the icon, or hides the text.\n- Adds settings for ring visibility, color, and thickness.\n- Switches to an indeterminate animation when Yandex exceeds its estimate.\n- Shows a short red animated signal for request or playback errors.\n- Updates the bottom-sheet status immediately when translated audio starts.\n- Fixes Android resource packaging for the countdown placement list.\n\n### Included base\n\n- Based on stable Morphe Patches 1.37.0.\n- Test pre-release; enable pre-release patches for this source in Morphe Manager.",
+  "download_url": "https://github.com/sashade8-ship-it/dual-vot-patches/releases/download/v1.37.0-dev.1-dualvot.4/patches-1.37.0-dev.1-dualvot.4.mpp",
   "signature_download_url": "",
-  "version": "1.37.0-dualvot.4-dev.1"
+  "version": "1.37.0-dev.1-dualvot.4"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.37.0-dualvot.4-dev.1",
+  "version": "1.37.0-dev.1-dualvot.4",
   "patches": [
     {
       "name": "Add to queue",

--- a/patches/src/main/resources/addresources/values-ru-rRU/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values-ru-rRU/youtube/strings.xml
@@ -1114,11 +1114,9 @@ Second \"item\" text"</string>
     <string name="dualvot_yandex_enabled_summary_off">Яндекс-перевод отключён</string>
     <string name="dualvot_yandex_timer_position_title">Расположение таймера</string>
     <string name="dualvot_yandex_timer_position_summary">Выберите, где показывать примерное оставшееся время на кнопке плеера</string>
-    <string-array name="dualvot_yandex_timer_position_entries">
-        <item>Внутри иконки</item>
-        <item>Под иконкой</item>
-        <item>Не показывать</item>
-    </string-array>
+    <string name="dualvot_yandex_timer_position_entry_inside">Внутри иконки</string>
+    <string name="dualvot_yandex_timer_position_entry_below">Под иконкой</string>
+    <string name="dualvot_yandex_timer_position_entry_hidden">Не показывать</string>
     <string name="dualvot_yandex_progress_ring_enabled_title">Показывать кольцо прогресса</string>
     <string name="dualvot_yandex_progress_ring_enabled_summary">Отображать ход подготовки перевода вокруг кнопки Яндекса</string>
     <string name="dualvot_yandex_progress_ring_color_title">Цвет кольца прогресса</string>

--- a/patches/src/main/resources/addresources/values/youtube/arrays.xml
+++ b/patches/src/main/resources/addresources/values/youtube/arrays.xml
@@ -693,4 +693,14 @@
         <item>ja</item>
         <item>ko</item>
     </string-array>
+    <string-array name="dualvot_yandex_timer_position_entries">
+        <item>@string/dualvot_yandex_timer_position_entry_inside</item>
+        <item>@string/dualvot_yandex_timer_position_entry_below</item>
+        <item>@string/dualvot_yandex_timer_position_entry_hidden</item>
+    </string-array>
+    <string-array name="dualvot_yandex_timer_position_entry_values">
+        <item>inside</item>
+        <item>below</item>
+        <item>hidden</item>
+    </string-array>
 </resources>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1241,16 +1241,9 @@ Limitation: Reverts to old style 'More videos' overlay"</string>
     <string name="dualvot_yandex_enabled_summary_off">Yandex translation is disabled</string>
     <string name="dualvot_yandex_timer_position_title">Countdown placement</string>
     <string name="dualvot_yandex_timer_position_summary">Choose where the estimated remaining time appears on the player button</string>
-    <string-array name="dualvot_yandex_timer_position_entries">
-        <item>Inside the icon</item>
-        <item>Below the icon</item>
-        <item>Hidden</item>
-    </string-array>
-    <string-array name="dualvot_yandex_timer_position_entry_values" translatable="false">
-        <item>inside</item>
-        <item>below</item>
-        <item>hidden</item>
-    </string-array>
+    <string name="dualvot_yandex_timer_position_entry_inside">Inside the icon</string>
+    <string name="dualvot_yandex_timer_position_entry_below">Below the icon</string>
+    <string name="dualvot_yandex_timer_position_entry_hidden">Hidden</string>
     <string name="dualvot_yandex_progress_ring_enabled_title">Show progress ring</string>
     <string name="dualvot_yandex_progress_ring_enabled_summary">Display translation progress around the Yandex player button</string>
     <string name="dualvot_yandex_progress_ring_color_title">Progress ring color</string>


### PR DESCRIPTION
## What changed

- Moved the Yandex countdown placement arrays out of `strings.xml` and into the existing YouTube `arrays.xml` resource file.
- Kept the displayed labels as normal localized strings for English and Russian.
- Renamed the test bundle to `1.37.0-dev.1-dualvot.4` so Morphe Manager selects it over stable `1.37.0-dualvot.3` when pre-release patches are enabled.
- Updated bundle metadata and changelog.

## Root cause

Arsclib rejects a `<string-array>` declared in the generated `res/values/strings.xml`. The previous version also ended in `.1`, while the Manager comparator uses the trailing numeric component and therefore considered it older than stable `.3`.

## Validation

- `:patches:buildAndroid --no-daemon` succeeds.
- Bundle manifest reports `1.37.0-dev.1-dualvot.4`.
- The built `.mpp` contains the array only in `addresources/values/youtube/arrays.xml`; English and Russian `strings.xml` contain only localized string entries.
- SHA-256: `ab0bd75a57a2a37daf06e53fbd4e8e174cab5203b0fe1737e5d02e837ed4a43e`.