### PR TITLE
chore: clarify Dual VoT preview version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
-## 1.37.0-dev.1-dualvot.4 (2026-07-27)
+## 1.37.0-dualvot.4-preview (2026-07-27)
 
-### Packaging fix
+### Preview naming and packaging fix
 
 * Move the countdown placement arrays to `arrays.xml` and keep their labels as
   localized string resources so Arsclib can encode the patched APK.
-* Use a Manager-compatible pre-release version order so the `dev` bundle is
-  selected over `1.37.0-dualvot.3` when pre-release patches are enabled.
+* Identify this explicitly as a Dual VoT preview without implying that the
+  underlying Morphe Patches 1.37.0 release is a development build.
+* Keep a Manager-compatible version order so the preview is selected over
+  `1.37.0-dualvot.3` when pre-release patches are enabled.
 
 ## 1.37.0-dualvot.4-dev.1 (2026-07-27)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.37.0-dev.1-dualvot.4
+version = 1.37.0-dualvot.4-preview

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-07-27T13:36:44",
-  "description": "## Dual VoT Patches 1.37.0-dev.1-dualvot.4\n\n### Configurable Yandex countdown\n\n- Adds an animated progress ring to the Yandex player button.\n- Shows the estimated remaining time inside or below the icon, or hides the text.\n- Adds settings for ring visibility, color, and thickness.\n- Switches to an indeterminate animation when Yandex exceeds its estimate.\n- Shows a short red animated signal for request or playback errors.\n- Updates the bottom-sheet status immediately when translated audio starts.\n- Fixes Android resource packaging for the countdown placement list.\n\n### Included base\n\n- Based on stable Morphe Patches 1.37.0.\n- Test pre-release; enable pre-release patches for this source in Morphe Manager.",
-  "download_url": "https://github.com/sashade8-ship-it/dual-vot-patches/releases/download/v1.37.0-dev.1-dualvot.4/patches-1.37.0-dev.1-dualvot.4.mpp",
+  "created_at": "2026-07-27T13:52:27",
+  "description": "## Dual VoT Patches 1.37.0-dualvot.4-preview\n\n### Configurable Yandex countdown\n\n- Adds an animated progress ring to the Yandex player button.\n- Shows the estimated remaining time inside or below the icon, or hides the text.\n- Adds settings for ring visibility, color, and thickness.\n- Switches to an indeterminate animation when Yandex exceeds its estimate.\n- Shows a short red animated signal for request or playback errors.\n- Updates the bottom-sheet status immediately when translated audio starts.\n- Fixes Android resource packaging for the countdown placement list.\n\n### Version meaning\n\n- Based on stable Morphe Patches 1.37.0.\n- `dualvot.4-preview` identifies this as a test build of Dual VoT, not a Morphe dev release.\n- Enable pre-release patches for this source in Morphe Manager.",
+  "download_url": "https://github.com/sashade8-ship-it/dual-vot-patches/releases/download/v1.37.0-dualvot.4-preview/patches-1.37.0-dualvot.4-preview.mpp",
   "signature_download_url": "",
-  "version": "1.37.0-dev.1-dualvot.4"
+  "version": "1.37.0-dualvot.4-preview"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.37.0-dev.1-dualvot.4",
+  "version": "1.37.0-dualvot.4-preview",
   "patches": [
     {
       "name": "Add to queue",


### PR DESCRIPTION
## What changed

- Renamed the test bundle from 1.37.0-dev.1-dualvot.4 to 1.37.0-dualvot.4-preview.
- Updated the Gradle version, bundle metadata, download URL, patch list and changelog.
- Documented that preview refers to the Dual VoT integration while the underlying Morphe base remains stable 1.37.0.

## Why

Placing dev.1 immediately after 1.37.0 made the test bundle look like an official Morphe development release. The new format clearly separates the Morphe base version from the Dual VoT preview channel.

## Validation

- :patches:buildAndroid --no-daemon succeeds.
- Bundle manifest reports 1.37.0-dualvot.4-preview.
- Built artifact: patches-1.37.0-dualvot.4-preview.mpp.
- SHA-256: c80819f71e42c031c68628f1b886d2aad1cd29cdb50a5ba21fbfbeaa25c284cd.