### PR TITLE
Fix Yandex countdown geometry and full VOT proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 1.37.0-dualvot.5-preview (2026-07-27)
+
+### Player button geometry
+
+* Draw the countdown inside the icon's square drawable bounds instead of the
+  player button's rectangular touch target.
+* Keep the ring circular and centered in portrait, landscape, and compact
+  players.
+* Stop changing the ImageView padding during countdown refreshes, preventing
+  the Yandex glyph and timer from shifting.
+* In the inside layout, replace the glyph with the timer instead of drawing
+  both on top of each other.
+
+### Full Yandex proxy
+
+* Route session creation, translation requests, source-audio uploads, status
+  polling, failed-audio recovery, and translated MP3 playback through the
+  configured VOT worker.
+* Preserve direct Yandex connections when the proxy is disabled.
+* Skip the separate direct OAuth validation request in proxy mode.
+* Stream large proxy upload envelopes to reduce peak memory use on older
+  Android devices.
+
 ## 1.37.0-dualvot.4-preview (2026-07-27)
 
 ### Preview naming and packaging fix

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/voiceovertranslation/yandex/YandexVotApiClient.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/patches/voiceovertranslation/yandex/YandexVotApiClient.java
@@ -59,6 +59,7 @@ import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
@@ -125,16 +126,35 @@ public class YandexVotApiClient {
      * @param originalUrl the original audio URL
      * @return proxied URL, or originalUrl on error
      */
+    private static boolean isProxyEnabled() {
+        return Settings.DUAL_VOT_YANDEX_AUDIO_PROXY_ENABLED.get()
+                && !Settings.DUAL_VOT_YANDEX_PROXY_URL.get().trim().isEmpty();
+    }
+
+    @NonNull
+    private static String getProxyBaseUrl() {
+        String configuredUrl = Settings.DUAL_VOT_YANDEX_PROXY_URL.get().trim();
+        if (!configuredUrl.matches("(?i)^https?://.*")) {
+            configuredUrl = "https://" + configuredUrl;
+        }
+        return configuredUrl.replaceAll("/+$", "");
+    }
+
+    @NonNull
+    private static String getApiUrl(@NonNull String path) {
+        return (isProxyEnabled()
+                ? getProxyBaseUrl()
+                : "https://" + YANDEX_API_HOST) + path;
+    }
+
     @NonNull
     public static String toProxyAudioUrl(@NonNull String originalUrl) {
         if (originalUrl.isEmpty()) {
             return originalUrl;
         }
-        String proxyHost = Settings.DUAL_VOT_YANDEX_PROXY_URL.get();
-        if (proxyHost.isEmpty()) {
+        if (!isProxyEnabled()) {
             return originalUrl;
         }
-        proxyHost = proxyHost.replaceFirst("^https?://", "").replaceAll("/+$", "");
         try {
             URI uri = new URI(originalUrl);
             String path = uri.getRawPath();
@@ -148,7 +168,7 @@ public class YandexVotApiClient {
                 pathTrimmed = pathTrimmed.substring(lastSlash + 1);
             }
             StringBuilder proxyUrl = new StringBuilder();
-            proxyUrl.append("https://").append(proxyHost);
+            proxyUrl.append(getProxyBaseUrl());
             proxyUrl.append("/video-translation/audio-proxy/");
             proxyUrl.append(pathTrimmed);
             if (query != null && !query.isEmpty()) {
@@ -160,6 +180,99 @@ public class YandexVotApiClient {
             Logger.printDebug(() -> "toProxyAudioUrl: invalid URL " + originalUrl);
             return originalUrl;
         }
+    }
+
+    private static void writeBinaryProxyRequest(
+            @NonNull OutputStream output,
+            @NonNull byte[] body,
+            @NonNull Map<String, String> headers
+    ) throws IOException {
+        StringBuilder json = new StringBuilder(16_384);
+        json.append("{\"headers\":");
+        appendJsonHeaders(json, headers);
+        json.append(",\"body\":[");
+        for (int i = 0; i < body.length; i++) {
+            if (i > 0) json.append(',');
+            json.append(body[i] & 0xFF);
+            if (json.length() >= 16_384) {
+                writeUtf8(output, json);
+                json.setLength(0);
+            }
+        }
+        json.append("]}");
+        writeUtf8(output, json);
+    }
+
+    private static void writeUtf8(
+            @NonNull OutputStream output,
+            @NonNull StringBuilder text
+    ) throws IOException {
+        output.write(text.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    @NonNull
+    private static byte[] wrapJsonProxyRequest(
+            @NonNull String jsonBody,
+            @NonNull Map<String, String> headers
+    ) {
+        StringBuilder json = new StringBuilder(jsonBody.length() + 256);
+        json.append("{\"headers\":");
+        appendJsonHeaders(json, headers);
+        json.append(",\"body\":").append(jsonBody).append('}');
+        return json.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static void appendJsonHeaders(
+            @NonNull StringBuilder json,
+            @NonNull Map<String, String> headers
+    ) {
+        json.append('{');
+        boolean first = true;
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            if (!first) json.append(',');
+            first = false;
+            appendJsonString(json, header.getKey());
+            json.append(':');
+            appendJsonString(json, header.getValue());
+        }
+        json.append('}');
+    }
+
+    private static void appendJsonString(@NonNull StringBuilder json, @NonNull String value) {
+        json.append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char character = value.charAt(i);
+            switch (character) {
+                case '"':
+                    json.append("\\\"");
+                    break;
+                case '\\':
+                    json.append("\\\\");
+                    break;
+                case '\b':
+                    json.append("\\b");
+                    break;
+                case '\f':
+                    json.append("\\f");
+                    break;
+                case '\n':
+                    json.append("\\n");
+                    break;
+                case '\r':
+                    json.append("\\r");
+                    break;
+                case '\t':
+                    json.append("\\t");
+                    break;
+                default:
+                    if (character < 0x20) {
+                        json.append(String.format(Locale.US, "\\u%04x", (int) character));
+                    } else {
+                        json.append(character);
+                    }
+            }
+        }
+        json.append('"');
     }
 
     public static TranslationResult requestTranslation(
@@ -299,9 +412,6 @@ public class YandexVotApiClient {
     }
 
     private static byte[] sendApiRequest(String path, byte[] body, String method, String oauthToken) throws IOException {
-        String workerUrl = "https://" + YANDEX_API_HOST + path;
-        Logger.printDebug(() -> "VOT sendApiRequest: " + method + " " + workerUrl);
-
         String vtransSignature = computeHmacHex(body);
         // Use existing session UUID or generate a new one (will be replaced when session is created)
         String uuid = sessionUuid != null ? sessionUuid : generateUuid();
@@ -309,36 +419,60 @@ public class YandexVotApiClient {
         String tokenSign = computeHmacHex(tokenData.getBytes(StandardCharsets.UTF_8));
         String vtransToken = tokenSign + ":" + tokenData;
 
-        HttpURLConnection connection = (HttpURLConnection) new URL(workerUrl).openConnection();
+        Map<String, String> yandexHeaders = new LinkedHashMap<>();
+        yandexHeaders.put("Accept", "application/x-protobuf");
+        yandexHeaders.put("Accept-Language", "en");
+        yandexHeaders.put("Content-Type", "application/x-protobuf");
+        yandexHeaders.put("User-Agent", USER_AGENT);
+        yandexHeaders.put("Pragma", "no-cache");
+        yandexHeaders.put("Cache-Control", "no-cache");
+        yandexHeaders.put("Vtrans-Signature", vtransSignature);
+        yandexHeaders.put("Sec-Vtrans-Token", vtransToken);
+        if (sessionSecretKey != null && !sessionSecretKey.isEmpty()) {
+            yandexHeaders.put("Sec-Vtrans-Sk", sessionSecretKey);
+        }
+        if (oauthToken != null && !oauthToken.isEmpty()) {
+            yandexHeaders.put("Authorization", "OAuth " + oauthToken);
+        }
+
+        boolean useProxy = isProxyEnabled();
+        String requestUrl = getApiUrl(path);
+        Logger.printDebug(() -> "VOT sendApiRequest: " + method + " " + requestUrl
+                + (useProxy ? " via VOT worker" : ""));
+
+        HttpURLConnection connection = (HttpURLConnection) new URL(requestUrl).openConnection();
         try {
             connection.setRequestMethod(method);
-            connection.setRequestProperty("Accept", "application/x-protobuf");
-            connection.setRequestProperty("Accept-Language", "en");
-            connection.setRequestProperty("Content-Type", "application/x-protobuf");
-            connection.setRequestProperty("User-Agent", USER_AGENT);
-            connection.setRequestProperty("Pragma", "no-cache");
-            connection.setRequestProperty("Cache-Control", "no-cache");
-            connection.setRequestProperty("Vtrans-Signature", vtransSignature);
-            connection.setRequestProperty("Sec-Vtrans-Token", vtransToken);
-            if (sessionSecretKey != null && !sessionSecretKey.isEmpty()) {
-                connection.setRequestProperty("Sec-Vtrans-Sk", sessionSecretKey);
-            }
-            if (oauthToken != null && !oauthToken.isEmpty()) {
-                connection.setRequestProperty("Authorization", "OAuth " + oauthToken);
+            if (useProxy) {
+                connection.setRequestProperty("Accept", "application/x-protobuf");
+                connection.setRequestProperty("Content-Type", "application/json");
+                connection.setRequestProperty("User-Agent", USER_AGENT);
+            } else {
+                for (Map.Entry<String, String> header : yandexHeaders.entrySet()) {
+                    connection.setRequestProperty(header.getKey(), header.getValue());
+                }
             }
             connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
             connection.setReadTimeout(READ_TIMEOUT_MS);
             connection.setDoOutput(true);
 
-            connection.setFixedLengthStreamingMode(body.length);
+            if (useProxy) {
+                connection.setChunkedStreamingMode(32 * 1024);
+            } else {
+                connection.setFixedLengthStreamingMode(body.length);
+            }
 
             try (OutputStream os = connection.getOutputStream()) {
-                os.write(body);
+                if (useProxy) {
+                    writeBinaryProxyRequest(os, body, yandexHeaders);
+                } else {
+                    os.write(body);
+                }
             }
 
             int responseCode = connection.getResponseCode();
             if (responseCode != 200) {
-                Logger.printDebug(() -> "VOT sendApiRequest: " + workerUrl
+                Logger.printDebug(() -> "VOT sendApiRequest: " + requestUrl
                         + " returned " + responseCode);
                 return null;
             }
@@ -393,24 +527,45 @@ public class YandexVotApiClient {
             String tokenSign = computeHmacHex(tokenData.getBytes(StandardCharsets.UTF_8));
             String summaryToken = tokenSign + ":" + tokenData;
 
-            String url = "https://" + YANDEX_API_HOST + path;
-            Logger.printDebug(() -> "VOT createSession: POST " + url);
+            Map<String, String> yandexHeaders = new LinkedHashMap<>();
+            yandexHeaders.put("Accept", "application/x-protobuf");
+            yandexHeaders.put("Content-Type", "application/x-protobuf");
+            yandexHeaders.put("User-Agent", USER_AGENT);
+            yandexHeaders.put("X-Ya-Summary-Token", summaryToken);
+            yandexHeaders.put("X-Ya-Summary-Sk", "");
 
-            HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+            boolean useProxy = isProxyEnabled();
+            String requestUrl = getApiUrl(path);
+            Logger.printDebug(() -> "VOT createSession: POST " + requestUrl
+                    + (useProxy ? " via VOT worker" : ""));
+
+            HttpURLConnection connection = (HttpURLConnection) new URL(requestUrl).openConnection();
             try {
                 connection.setRequestMethod("POST");
-                connection.setRequestProperty("Accept", "application/x-protobuf");
-                connection.setRequestProperty("Content-Type", "application/x-protobuf");
-                connection.setRequestProperty("User-Agent", USER_AGENT);
-                connection.setRequestProperty("X-Ya-Summary-Token", summaryToken);
-                connection.setRequestProperty("X-Ya-Summary-Sk", "");
+                if (useProxy) {
+                    connection.setRequestProperty("Accept", "application/x-protobuf");
+                    connection.setRequestProperty("Content-Type", "application/json");
+                    connection.setRequestProperty("User-Agent", USER_AGENT);
+                } else {
+                    for (Map.Entry<String, String> header : yandexHeaders.entrySet()) {
+                        connection.setRequestProperty(header.getKey(), header.getValue());
+                    }
+                }
                 connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
                 connection.setReadTimeout(READ_TIMEOUT_MS);
                 connection.setDoOutput(true);
-                connection.setFixedLengthStreamingMode(body.length);
+                if (useProxy) {
+                    connection.setChunkedStreamingMode(32 * 1024);
+                } else {
+                    connection.setFixedLengthStreamingMode(body.length);
+                }
 
                 try (OutputStream os = connection.getOutputStream()) {
-                    os.write(body);
+                    if (useProxy) {
+                        writeBinaryProxyRequest(os, body, yandexHeaders);
+                    } else {
+                        os.write(body);
+                    }
                 }
 
                 int responseCode = connection.getResponseCode();
@@ -443,7 +598,7 @@ public class YandexVotApiClient {
                 connection.disconnect();
             }
         } catch (UnknownHostException e) {
-            Logger.printException(() -> "VOT createSession failed: DNS resolution error for " + YANDEX_API_HOST, e);
+            Logger.printException(() -> "VOT createSession failed: DNS resolution error", e);
             return false;
         } catch (SocketTimeoutException e) {
             Logger.printException(() -> "VOT createSession failed: connection timeout", e);
@@ -477,6 +632,9 @@ public class YandexVotApiClient {
      */
     public static boolean isValidOAuthToken(String token) {
         if (token == null || token.isEmpty()) return false;
+        // The worker forwards the OAuth header to the VOT API. Avoid making a
+        // separate direct login.yandex.ru request when Yandex is region-blocked.
+        if (isProxyEnabled()) return true;
         // Return cached result if we already validated this exact token.
         if (token.equals(lastValidatedToken)) return tokenIsValid;
         try {
@@ -617,23 +775,42 @@ public class YandexVotApiClient {
      * Sends a JSON request to the Yandex VOT API (for fail-audio-js endpoint).
      */
     private static void sendJsonRequest(String path, String jsonBody, String method) throws IOException {
-        String workerUrl = "https://" + YANDEX_API_HOST + path;
+        Map<String, String> yandexHeaders = new LinkedHashMap<>();
+        yandexHeaders.put("Content-Type", "application/json");
+        yandexHeaders.put("Accept", "application/json");
+        yandexHeaders.put("User-Agent", USER_AGENT);
 
-        HttpURLConnection connection = (HttpURLConnection) new URL(workerUrl).openConnection();
+        boolean useProxy = isProxyEnabled();
+        String requestUrl = getApiUrl(path);
+        byte[] payloadBytes = useProxy
+                ? wrapJsonProxyRequest(jsonBody, yandexHeaders)
+                : jsonBody.getBytes(StandardCharsets.UTF_8);
+
+        HttpURLConnection connection = (HttpURLConnection) new URL(requestUrl).openConnection();
         try {
             connection.setRequestMethod(method);
-            connection.setRequestProperty("Content-Type", "application/json");
-            connection.setRequestProperty("Accept", "application/json");
-            connection.setRequestProperty("User-Agent", USER_AGENT);
+            if (useProxy) {
+                connection.setRequestProperty("Content-Type", "application/json");
+                connection.setRequestProperty("Accept", "application/json");
+                connection.setRequestProperty("User-Agent", USER_AGENT);
+            } else {
+                for (Map.Entry<String, String> header : yandexHeaders.entrySet()) {
+                    connection.setRequestProperty(header.getKey(), header.getValue());
+                }
+            }
             connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
             connection.setReadTimeout(READ_TIMEOUT_MS);
             connection.setDoOutput(true);
 
-            byte[] payloadBytes = jsonBody.getBytes(StandardCharsets.UTF_8);
             connection.setFixedLengthStreamingMode(payloadBytes.length);
 
             try (OutputStream os = connection.getOutputStream()) {
                 os.write(payloadBytes);
+            }
+            int responseCode = connection.getResponseCode();
+            if (responseCode < 200 || responseCode >= 300) {
+                Logger.printDebug(() -> "VOT sendJsonRequest: " + requestUrl
+                        + " returned " + responseCode);
             }
         } finally {
             connection.disconnect();

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/YandexVoiceOverTranslationButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/YandexVoiceOverTranslationButton.java
@@ -52,6 +52,7 @@ import android.graphics.Color;
 import android.graphics.ColorFilter;
 import android.graphics.Paint;
 import android.graphics.PixelFormat;
+import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
@@ -101,9 +102,13 @@ public final class YandexVoiceOverTranslationButton {
                     });
             overlayButtonRef = button != null ? new WeakReference<>(button) : null;
             if (button != null) {
-                CountdownDrawable drawable = new CountdownDrawable(button);
+                CountdownDrawable drawable = new CountdownDrawable(button, button.getDrawable());
                 countdownDrawableRef = new WeakReference<>(drawable);
-                button.setForeground(drawable);
+                // Keep the indicator in the same square drawable coordinate space as
+                // the icon. A foreground receives the entire, sometimes rectangular,
+                // touch target and produces an oversized oval in compact players.
+                button.setImageDrawable(drawable);
+                button.setImageAlpha(255);
                 button.post(STATE_REFRESH_CALLBACK);
             } else {
                 countdownDrawableRef = null;
@@ -122,7 +127,6 @@ public final class YandexVoiceOverTranslationButton {
             WeakReference<ImageView> ref = overlayButtonRef;
             ImageView overlay = ref != null ? ref.get() : null;
             if (overlay != null) {
-                overlay.setImageAlpha(alpha);
                 overlay.removeCallbacks(PROGRESS_TICK);
 
                 boolean waiting = YandexVoiceOverTranslationPatch.translationStarting;
@@ -131,8 +135,6 @@ public final class YandexVoiceOverTranslationButton {
                 float progress = YandexVoiceOverTranslationPatch.getWaitingProgressFraction();
                 String timerPosition = Settings.DUAL_VOT_YANDEX_TIMER_POSITION.get();
                 boolean showTimer = waiting && !"hidden".equals(timerPosition);
-
-                updateIconPadding(overlay, waiting && "below".equals(timerPosition));
 
                 WeakReference<CountdownDrawable> drawableRef = countdownDrawableRef;
                 CountdownDrawable drawable = drawableRef != null ? drawableRef.get() : null;
@@ -146,7 +148,8 @@ public final class YandexVoiceOverTranslationButton {
                             Settings.DUAL_VOT_YANDEX_PROGRESS_RING_COLOR.get(),
                             Settings.DUAL_VOT_YANDEX_PROGRESS_RING_THICKNESS.get(),
                             seconds,
-                            progress
+                            progress,
+                            alpha
                     );
                 }
 
@@ -165,25 +168,14 @@ public final class YandexVoiceOverTranslationButton {
         }
     }
 
-    private static void updateIconPadding(ImageView button, boolean timerBelow) {
-        int size = Math.min(button.getWidth(), button.getHeight());
-        int side = timerBelow ? Math.round(size * 0.12f) : 0;
-        int top = timerBelow ? Math.round(size * 0.04f) : 0;
-        int bottom = timerBelow ? Math.round(size * 0.25f) : 0;
-        if (button.getPaddingLeft() != side
-                || button.getPaddingTop() != top
-                || button.getPaddingRight() != side
-                || button.getPaddingBottom() != bottom) {
-            button.setPadding(side, top, side, bottom);
-        }
-    }
-
     private static final class CountdownDrawable extends Drawable {
+        private final Drawable icon;
         private final Paint ringPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
         private final Paint textPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
         private final Paint textBackgroundPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
         private final RectF ringBounds = new RectF();
         private final RectF textBackgroundBounds = new RectF();
+        private final Rect iconBounds = new Rect();
         private final float density;
 
         private boolean waiting;
@@ -195,9 +187,14 @@ public final class YandexVoiceOverTranslationButton {
         private float ringThicknessPx;
         private int remainingSeconds = -1;
         private float progress = -1.0f;
+        private int iconAlpha = 128;
 
-        CountdownDrawable(ImageView owner) {
+        CountdownDrawable(ImageView owner, Drawable icon) {
             density = owner.getResources().getDisplayMetrics().density;
+            Drawable.ConstantState iconState = icon.getConstantState();
+            this.icon = iconState != null
+                    ? iconState.newDrawable(owner.getResources()).mutate()
+                    : icon.mutate();
             ringPaint.setStyle(Paint.Style.STROKE);
             ringPaint.setStrokeCap(Paint.Cap.ROUND);
 
@@ -218,7 +215,8 @@ public final class YandexVoiceOverTranslationButton {
                 String configuredColor,
                 int configuredThicknessDp,
                 int remainingSeconds,
-                float progress
+                float progress,
+                int iconAlpha
         ) {
             this.waiting = waiting;
             this.error = error;
@@ -229,14 +227,20 @@ public final class YandexVoiceOverTranslationButton {
             this.ringThicknessPx = Math.max(1.0f, configuredThicknessDp * density);
             this.remainingSeconds = remainingSeconds;
             this.progress = progress;
+            this.iconAlpha = Math.max(0, Math.min(255, iconAlpha));
             invalidateSelf();
         }
 
         @Override
         public void draw(Canvas canvas) {
-            if (!waiting && !error) return;
+            updateGeometry();
 
-            if (showRing || error) {
+            // Replacing the icon while the timer is inside avoids drawing digits
+            // across the translate glyph. All other states retain the icon.
+            if (!(waiting && showTimer && !timerBelow)) {
+                drawIcon(canvas);
+            }
+            if ((showRing && waiting) || error) {
                 drawRing(canvas);
             }
             if (showTimer && waiting) {
@@ -244,14 +248,64 @@ public final class YandexVoiceOverTranslationButton {
             }
         }
 
+        private void updateGeometry() {
+            Rect bounds = getBounds();
+            float size = Math.min(bounds.width(), bounds.height());
+            float centerX = bounds.exactCenterX();
+            float centerY = bounds.exactCenterY();
+            float strokeInset = ringThicknessPx / 2.0f + 0.75f * density;
+
+            if (waiting && showTimer && timerBelow) {
+                float iconAreaSide = Math.max(1.0f, size * 0.68f);
+                float compositionTop = centerY - size / 2.0f;
+                float iconCenterY = compositionTop + size * 0.36f;
+                setCenteredSquare(
+                        ringBounds,
+                        centerX,
+                        iconCenterY,
+                        Math.max(1.0f, iconAreaSide - 2.0f * strokeInset)
+                );
+            } else {
+                setCenteredSquare(
+                        ringBounds,
+                        centerX,
+                        centerY,
+                        Math.max(1.0f, size - 2.0f * strokeInset)
+                );
+            }
+        }
+
+        private static void setCenteredSquare(
+                RectF target,
+                float centerX,
+                float centerY,
+                float side
+        ) {
+            float half = side / 2.0f;
+            target.set(centerX - half, centerY - half, centerX + half, centerY + half);
+        }
+
+        private void drawIcon(Canvas canvas) {
+            boolean ringVisible = (showRing && waiting) || error;
+            if (!ringVisible && !(waiting && showTimer && timerBelow)) {
+                iconBounds.set(getBounds());
+            } else {
+                float inset = ringThicknessPx / 2.0f + 1.25f * density;
+                iconBounds.set(
+                        Math.round(ringBounds.left + inset),
+                        Math.round(ringBounds.top + inset),
+                        Math.round(ringBounds.right - inset),
+                        Math.round(ringBounds.bottom - inset)
+                );
+            }
+            if (iconBounds.width() <= 0 || iconBounds.height() <= 0) return;
+
+            icon.setBounds(iconBounds);
+            icon.setAlpha(iconAlpha);
+            icon.draw(canvas);
+        }
+
         private void drawRing(Canvas canvas) {
-            float inset = ringThicknessPx / 2.0f + density;
-            ringBounds.set(
-                    getBounds().left + inset,
-                    getBounds().top + inset,
-                    getBounds().right - inset,
-                    getBounds().bottom - inset
-            );
             ringPaint.setStrokeWidth(ringThicknessPx);
 
             if (error) {
@@ -282,20 +336,20 @@ public final class YandexVoiceOverTranslationButton {
 
         private void drawTimer(Canvas canvas) {
             String text = formatTimerText(remainingSeconds);
-            float width = getBounds().width();
-            float height = getBounds().height();
-            float textSize = Math.min(width, height) * (timerBelow ? 0.18f : 0.24f);
-            textPaint.setTextSize(Math.max(8.0f * density, textSize));
+            Rect bounds = getBounds();
+            float size = Math.min(bounds.width(), bounds.height());
+            float textSize = size * (timerBelow ? 0.22f : 0.29f);
+            textPaint.setTextSize(Math.max((timerBelow ? 5.5f : 7.0f) * density, textSize));
 
             Paint.FontMetrics metrics = textPaint.getFontMetrics();
-            float centerX = getBounds().exactCenterX();
+            float centerX = bounds.exactCenterX();
             float centerY = timerBelow
-                    ? getBounds().bottom - Math.max(6.0f * density, height * 0.13f)
-                    : getBounds().exactCenterY();
+                    ? bounds.exactCenterY() + size * 0.35f
+                    : bounds.exactCenterY();
             float baseline = centerY - (metrics.ascent + metrics.descent) / 2.0f;
             float textWidth = textPaint.measureText(text);
-            float horizontalPadding = 3.0f * density;
-            float verticalPadding = 1.0f * density;
+            float horizontalPadding = (timerBelow ? 1.5f : 2.25f) * density;
+            float verticalPadding = (timerBelow ? 0.25f : 0.75f) * density;
 
             textBackgroundBounds.set(
                     centerX - textWidth / 2.0f - horizontalPadding,
@@ -303,13 +357,13 @@ public final class YandexVoiceOverTranslationButton {
                     centerX + textWidth / 2.0f + horizontalPadding,
                     baseline + metrics.descent + verticalPadding
             );
-            float radius = 4.0f * density;
+            float radius = textBackgroundBounds.height() / 2.0f;
             canvas.drawRoundRect(textBackgroundBounds, radius, radius, textBackgroundPaint);
             canvas.drawText(text, centerX, baseline, textPaint);
         }
 
         private static String formatTimerText(int seconds) {
-            if (seconds <= 0) return "…";
+            if (seconds <= 0) return "\u2026";
             if (seconds >= 60) {
                 int minutes = (seconds + 59) / 60;
                 return str("dualvot_yandex_button_time_minutes", minutes);
@@ -333,6 +387,7 @@ public final class YandexVoiceOverTranslationButton {
         public void setAlpha(int alpha) {
             ringPaint.setAlpha(alpha);
             textPaint.setAlpha(alpha);
+            icon.setAlpha(alpha);
             invalidateSelf();
         }
 
@@ -340,7 +395,18 @@ public final class YandexVoiceOverTranslationButton {
         public void setColorFilter(@Nullable ColorFilter colorFilter) {
             ringPaint.setColorFilter(colorFilter);
             textPaint.setColorFilter(colorFilter);
+            icon.setColorFilter(colorFilter);
             invalidateSelf();
+        }
+
+        @Override
+        public int getIntrinsicWidth() {
+            return icon.getIntrinsicWidth();
+        }
+
+        @Override
+        public int getIntrinsicHeight() {
+            return icon.getIntrinsicHeight();
         }
 
         @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.37.0-dualvot.4-preview
+version = 1.37.0-dualvot.5-preview

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-07-27T13:52:27",
-  "description": "## Dual VoT Patches 1.37.0-dualvot.4-preview\n\n### Configurable Yandex countdown\n\n- Adds an animated progress ring to the Yandex player button.\n- Shows the estimated remaining time inside or below the icon, or hides the text.\n- Adds settings for ring visibility, color, and thickness.\n- Switches to an indeterminate animation when Yandex exceeds its estimate.\n- Shows a short red animated signal for request or playback errors.\n- Updates the bottom-sheet status immediately when translated audio starts.\n- Fixes Android resource packaging for the countdown placement list.\n\n### Version meaning\n\n- Based on stable Morphe Patches 1.37.0.\n- `dualvot.4-preview` identifies this as a test build of Dual VoT, not a Morphe dev release.\n- Enable pre-release patches for this source in Morphe Manager.",
-  "download_url": "https://github.com/sashade8-ship-it/dual-vot-patches/releases/download/v1.37.0-dualvot.4-preview/patches-1.37.0-dualvot.4-preview.mpp",
+  "created_at": "2026-07-27T18:30:00",
+  "description": "## Dual VoT Patches 1.37.0-dualvot.5-preview\n\n### Player button geometry\n\n- Keeps the countdown ring circular and attached to the Yandex icon in portrait, landscape, and compact players.\n- Centers the timer inside the icon or places it below without changing the button footprint.\n- Stops the Yandex glyph from shifting while the player controls are visible.\n\n### Full Yandex proxy\n\n- Routes session creation, translation requests, source-audio uploads, status polling, and translated audio through the configured VOT worker.\n- Keeps direct Yandex access unchanged when the proxy is disabled.\n- Streams large proxy upload envelopes to reduce memory use on older Android devices.\n\n### Version meaning\n\n- Based on stable Morphe Patches 1.37.0.\n- `dualvot.5-preview` is a test build of Dual VoT, not a Morphe dev release.\n- Enable pre-release patches for this source in Morphe Manager.",
+  "download_url": "https://github.com/sashade8-ship-it/dual-vot-patches/releases/download/v1.37.0-dualvot.5-preview/patches-1.37.0-dualvot.5-preview.mpp",
   "signature_download_url": "",
-  "version": "1.37.0-dualvot.4-preview"
+  "version": "1.37.0-dualvot.5-preview"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.37.0-dualvot.4-preview",
+  "version": "1.37.0-dualvot.5-preview",
   "patches": [
     {
       "name": "Add to queue",

--- a/patches/src/main/resources/addresources/values-ru-rRU/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values-ru-rRU/youtube/strings.xml
@@ -1133,11 +1133,11 @@ Second \"item\" text"</string>
     <string name="dualvot_yandex_translation_volume_summary">Громкость переведённой аудиодорожки (0-100). По умолчанию: 100</string>
     <string name="dualvot_yandex_original_audio_volume_title">Громкость оригинального аудио</string>
     <string name="dualvot_yandex_original_audio_volume_summary">Громкость оригинальной видеодорожки во время перевода (0-100). По умолчанию: 30</string>
-    <string name="dualvot_yandex_audio_proxy_title">Прокси аудиопотока</string>
-    <string name="dualvot_yandex_audio_proxy_enabled_summary">Включать только в случае недоступности серверов Яндекса</string>
-    <string name="dualvot_yandex_audio_proxy_summary">Включать только в случае недоступности серверов Яндекса</string>
-    <string name="dualvot_yandex_audio_proxy_summary_on">Аудиопоток проксируется через worker</string>
-    <string name="dualvot_yandex_audio_proxy_summary_off">Аудиопоток использует прямую ссылку</string>
+    <string name="dualvot_yandex_audio_proxy_title">Прокси Яндекс-перевода</string>
+    <string name="dualvot_yandex_audio_proxy_enabled_summary">Запросы перевода и аудио идут через VOT worker</string>
+    <string name="dualvot_yandex_audio_proxy_summary">Используйте, если сервисы Яндекса недоступны в вашем регионе</string>
+    <string name="dualvot_yandex_audio_proxy_summary_on">Запросы перевода и аудио идут через VOT worker</string>
+    <string name="dualvot_yandex_audio_proxy_summary_off">Запросы перевода и аудио идут напрямую к Яндексу</string>
     <string name="dualvot_yandex_proxy_url_title">Прокси-сервер</string>
     <string name="dualvot_yandex_proxy_url_summary">Хост прокси VOT worker. По умолчанию: vot-worker.eu.cc</string>
     <string name="dualvot_yandex_use_live_voices_title">Живые голоса</string>

--- a/patches/src/main/resources/addresources/values/youtube/strings.xml
+++ b/patches/src/main/resources/addresources/values/youtube/strings.xml
@@ -1260,11 +1260,11 @@ Limitation: Reverts to old style 'More videos' overlay"</string>
     <string name="dualvot_yandex_translation_volume_summary">Volume of the translated audio track (0-100). Default: 100</string>
     <string name="dualvot_yandex_original_audio_volume_title">Original audio volume</string>
     <string name="dualvot_yandex_original_audio_volume_summary">Volume of the original video track when translation is playing (0-100). Default: 30</string>
-    <string name="dualvot_yandex_audio_proxy_title">Proxy audio stream</string>
-    <string name="dualvot_yandex_audio_proxy_enabled_summary">Enable only if Yandex servers are unreachable</string>
-    <string name="dualvot_yandex_audio_proxy_summary">Enable only if Yandex servers are unreachable</string>
-    <string name="dualvot_yandex_audio_proxy_summary_on">Audio is routed through a proxy worker</string>
-    <string name="dualvot_yandex_audio_proxy_summary_off">Audio is downloaded directly from Yandex servers</string>
+    <string name="dualvot_yandex_audio_proxy_title">Proxy Yandex translation</string>
+    <string name="dualvot_yandex_audio_proxy_enabled_summary">Translation requests and audio are routed through the VOT worker</string>
+    <string name="dualvot_yandex_audio_proxy_summary">Use if Yandex services are unavailable in your region</string>
+    <string name="dualvot_yandex_audio_proxy_summary_on">Translation requests and audio are routed through the VOT worker</string>
+    <string name="dualvot_yandex_audio_proxy_summary_off">Translation requests and audio connect directly to Yandex</string>
     <string name="dualvot_yandex_proxy_url_title">Proxy server</string>
     <string name="dualvot_yandex_proxy_url_summary">VOT worker proxy host. Default: vot-worker.eu.cc</string>
     <string name="dualvot_yandex_use_live_voices_title">Live voices</string>


### PR DESCRIPTION
## Summary

- render the Yandex countdown inside the icon drawable so the ring stays circular and the glyph no longer shifts
- route session creation, translation/poll requests, source-audio uploads, recovery requests, and translated audio through the configured VOT worker
- publish Manager metadata for 1.37.0-dualvot.5-preview

## Verification

- ./gradlew :patches:buildAndroid --no-daemon
- verified MPP manifest version and 132-patch metadata
- verified patches-bundle.json and patches-list.json parse and agree on the version
- verified ot-worker.eu.cc/health returns HTTP 200

## Runtime testing requested

- portrait, landscape, and compact player countdown alignment
- proxy-enabled translation in a region where Yandex domains are blocked, without a full-device VPN