### PR TITLE
fix: run updater controller from main

### DIFF
--- a/.github/scripts/test_sync_upstream.py
+++ b/.github/scripts/test_sync_upstream.py
@@ -14,6 +14,16 @@ SPEC.loader.exec_module(sync_upstream)
 
 
 class SyncUpstreamTests(unittest.TestCase):
+    def test_channel_workflow_runs_current_controller_from_main(self):
+        workflow = (
+            MODULE_PATH.parents[1] / "workflows" / "upstream_sync_channel.yml"
+        ).read_text(encoding="utf-8")
+        self.assertEqual(workflow.count("ref: main"), 2)
+        self.assertNotIn(
+            "ref: ${{ inputs.channel == 'stable' && 'main' || 'dev' }}",
+            workflow,
+        )
+
     def test_extracts_official_base_from_dual_version(self):
         self.assertEqual(
             sync_upstream.upstream_base("1.37.0-dualvot.3"),

--- a/.github/workflows/upstream_sync_channel.yml
+++ b/.github/workflows/upstream_sync_channel.yml
@@ -20,10 +20,12 @@ jobs:
       updated: ${{ steps.prepare.outputs.updated }}
       version: ${{ steps.prepare.outputs.version }}
     steps:
-      - name: Checkout target branch
+      - name: Checkout automation controller
         uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.channel == 'stable' && 'main' || 'dev' }}
+          # Automation must always run from main. The script checks out the
+          # requested target branch after it has loaded the current code.
+          ref: main
           fetch-depth: 0
           persist-credentials: false
 
@@ -68,10 +70,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout target branch
+      - name: Checkout automation controller
         uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.channel == 'stable' && 'main' || 'dev' }}
+          # In particular, do not execute an outdated publisher from dev.
+          ref: main
           fetch-depth: 0
 
       - name: Setup Python


### PR DESCRIPTION
## Summary

- always load the upstream updater and publisher from `main`
- let the loaded script check out and update the requested stable/dev target
- prevent stale dev automation from resetting the Dual VoT revision or missing publisher fixes
- add a regression test for the workflow checkout policy

## Root cause

The reusable workflow definition came from `main`, but both jobs checked out
`dev` before running `sync_upstream.py`. That executed the old script stored in
the target branch, so the new Git identity and shared `dualvot.7` version logic
were never used.

## Validation

- 9 updater unit/regression tests pass
- `git diff --check` passes
