### PR TITLE
fix: restore stable Manager metadata

### DIFF
--- a/.github/scripts/sync_upstream.py
+++ b/.github/scripts/sync_upstream.py
@@ -217,6 +217,22 @@ def validate_version(version: str) -> None:
         raise SyncError(f"Unsafe or unsupported upstream version: {version!r}")
 
 
+def validate_manager_local_datetime(value: object) -> None:
+    if not isinstance(value, str):
+        raise SyncError("patches-bundle.json created_at must be a string")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise SyncError(
+            f"Invalid patches-bundle.json created_at: {value!r}"
+        ) from error
+    if parsed.tzinfo is not None:
+        raise SyncError(
+            "patches-bundle.json created_at must be a timezone-free "
+            "LocalDateTime for Morphe Manager"
+        )
+
+
 def set_gradle_version(version: str) -> None:
     path = ROOT / "gradle.properties"
     text = path.read_text(encoding="utf-8")
@@ -396,6 +412,7 @@ def validate_candidate(version: str) -> Path:
     metadata = json.loads((ROOT / "patches-bundle.json").read_text(encoding="utf-8"))
     if metadata.get("version") != version:
         raise SyncError("patches-bundle.json version mismatch")
+    validate_manager_local_datetime(metadata.get("created_at"))
 
     return artifact
 

--- a/.github/scripts/test_sync_upstream.py
+++ b/.github/scripts/test_sync_upstream.py
@@ -56,6 +56,18 @@ class SyncUpstreamTests(unittest.TestCase):
         with self.assertRaises(sync_upstream.SyncError):
             sync_upstream.validate_version("1.38.0;echo-danger")
 
+    def test_accepts_manager_local_datetime_without_timezone(self):
+        sync_upstream.validate_manager_local_datetime("2026-07-28T10:49:38")
+
+    def test_rejects_manager_datetime_with_timezone(self):
+        for timestamp in (
+            "2026-07-28T12:49:38+02:00",
+            "2026-07-28T10:49:38Z",
+        ):
+            with self.subTest(timestamp=timestamp):
+                with self.assertRaises(sync_upstream.SyncError):
+                    sync_upstream.validate_manager_local_datetime(timestamp)
+
     def test_extracts_only_dual_changelog_sections(self):
         changelog = """## 1.38.0-dualvot.1 (2026-07-27)
 

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,5 +1,5 @@
 {
-  "created_at": "2026-07-28T12:40:00+02:00",
+  "created_at": "2026-07-28T10:49:38",
   "description": "## Dual VoT Patches 1.37.0-dualvot.7\n\n### Stable Dual VoT release\n\n- Graduates the tested Yandex countdown and player-button improvements from preview.\n- Keeps the countdown halo centered across orientations, timer positions, thicknesses, and layouts with additional player buttons.\n- Keeps the Yandex button state synchronized with translated playback.\n- Makes the Yandex audio controls scrollable so voice style and proxy settings remain reachable on short landscape screens.\n- Includes the improved new-video request flow and complete optional Yandex proxy routing.\n\n### Included base\n\n- Based on stable Morphe Patches 1.37.0.\n- Includes both the built-in Google/other translation and Yandex translation with mutually exclusive player controls.",
   "download_url": "https://github.com/sashade8-ship-it/dual-vot-patches/releases/download/v1.37.0-dualvot.7/patches-1.37.0-dualvot.7.mpp",
   "signature_download_url": "",


### PR DESCRIPTION
## What changed

- replace the stable bundle timestamp with the timezone-free `LocalDateTime`
  format required by Morphe Manager
- validate `patches-bundle.json.created_at` before automated publication
- reject timezone offsets and `Z` timestamps in updater regression tests

## Root cause

The stable metadata used `2026-07-28T12:40:00+02:00`. Custom sources are
deserialized by Morphe Manager directly into `kotlinx.datetime.LocalDateTime`,
which does not accept a timezone offset. The dev metadata used the compatible
timezone-free format and therefore continued to work.

## User impact

After this reaches `main`, adding the repository with pre-release patches
disabled can load `1.37.0-dualvot.7` normally again.

## Validation

- 11 updater unit/regression tests pass
- public stable JSON and `.mpp` URLs return HTTP 200
- `git diff --check` passes
