### PR TITLE
fix: unblock Morphe dev.3 upstream sync

### DIFF
--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/VoiceOverTranslationButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/VoiceOverTranslationButton.java
@@ -18,7 +18,7 @@ import java.lang.ref.WeakReference;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
-import app.morphe.extension.youtube.patches.voiceovertranslation.VoiceOverTranslationCoordinator;
+import app.morphe.extension.youtube.patches.voiceovertranslation.VoiceOverTranslationPatch;
 import app.morphe.extension.youtube.patches.voiceovertranslation.VotBottomSheet;
 import app.morphe.extension.youtube.settings.Settings;
 
@@ -38,13 +38,15 @@ public final class VoiceOverTranslationButton {
         try {
             if (RESTORE_OLD_PLAYER_BUTTONS || !Settings.VOT_ENABLED.get()) return;
 
-            VoiceOverTranslationCoordinator.addOnStateChangeCallback(STATE_REFRESH_CALLBACK);
+            app.morphe.extension.youtube.patches.voiceovertranslation.VoiceOverTranslationCoordinator
+                    .addOnStateChangeCallback(STATE_REFRESH_CALLBACK);
 
             ImageView button = PlayerOverlayButton.addButton(
                     controlsView,
                     "morphe_yt_vot_bold",
                     view -> {
-                        VoiceOverTranslationCoordinator.toggleOfficial();
+                        app.morphe.extension.youtube.patches.voiceovertranslation
+                                .VoiceOverTranslationCoordinator.toggleOfficial();
                         refreshActivatedState();
                     },
                     view -> {
@@ -63,7 +65,8 @@ public final class VoiceOverTranslationButton {
         try {
             if (!RESTORE_OLD_PLAYER_BUTTONS) return;
 
-            VoiceOverTranslationCoordinator.addOnStateChangeCallback(STATE_REFRESH_CALLBACK);
+            app.morphe.extension.youtube.patches.voiceovertranslation.VoiceOverTranslationCoordinator
+                    .addOnStateChangeCallback(STATE_REFRESH_CALLBACK);
 
             legacy = new LegacyPlayerControlButton(
                     controlsView,
@@ -72,7 +75,8 @@ public final class VoiceOverTranslationButton {
                     "morphe_yt_vot",
                     Settings.VOT_ENABLED,
                     view -> {
-                        VoiceOverTranslationCoordinator.toggleOfficial();
+                        app.morphe.extension.youtube.patches.voiceovertranslation
+                                .VoiceOverTranslationCoordinator.toggleOfficial();
                         refreshActivatedState();
                     },
                     view -> {
@@ -88,7 +92,11 @@ public final class VoiceOverTranslationButton {
     private static void refreshActivatedState() {
         Utils.verifyOnMainThread();
         try {
-            final int alpha = VoiceOverTranslationCoordinator.isOfficialActive() ? 255 : 128;
+            final int alpha =
+                    app.morphe.extension.youtube.patches.voiceovertranslation
+                                    .VoiceOverTranslationCoordinator.isOfficialActive()
+                            ? 255
+                            : 128;
             WeakReference<ImageView> ref = overlayButtonRef;
             ImageView overlay = ref != null ? ref.get() : null;
             if (overlay != null) {


### PR DESCRIPTION
## What changed

- keeps the upstream `VoiceOverTranslationPatch` import block unchanged before the Morphe `v1.38.0-dev.3` merge;
- uses fully qualified `VoiceOverTranslationCoordinator` calls for the Dual VoT behavior.

## Why

The scheduled upstream sync stopped while merging Morphe `v1.38.0-dev.3`.
Generated and protected files were resolved automatically, but
`VoiceOverTranslationButton.java` had a real three-way import conflict.
This compatibility change removes that source conflict without weakening the
automation guardrails or changing Dual VoT runtime behavior.

## Impact

After this lands on `dev`, the normal `Sync Morphe upstream` workflow can merge,
build, validate, and publish `1.38.0-dev.3-dualvot.8.1`.

## Validation

- `python .github/scripts/test_sync_upstream.py` — 11 tests passed.
- `git diff --check` — passed.
- `git merge-tree --write-tree HEAD v1.38.0-dev.3` — no conflict remains in
  `VoiceOverTranslationButton.java`; only controller-managed generated/protected
  files remain.
- Offline `:patches:buildAndroid` on local JDK 21 produced
  `patches-1.38.0-dev.2-dualvot.8.1-fix-dev3.mpp` (8,672,429 bytes).
