### PR TITLE
release: Dual VoT 1.37.0-dualvot.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.37.0-dualvot.8.2 (2026-07-30)
+
+### Upstream sync compatibility
+
+* Prevent a three-way import conflict in the official voice-over translation
+  player button when Morphe changes the legacy-controls access style.
+* Keep all Dual VoT coordinator behavior unchanged while allowing future
+  Morphe updates to merge automatically.
+
 ## 1.37.0-dualvot.8.1 (2026-07-30)
 
 ### Yandex player button

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ All modifications made by Morphe, along with their dates, can be found in the Gi
 #### Patches list
 
 <!-- PATCHES_START -->
-> **[v1.37.0-dualvot.8.1](https://github.com/sashade8-ship-it/dual-vot-patches/releases/tag/v1.37.0-dualvot.8.1)**&nbsp;&nbsp;•&nbsp;&nbsp;`main`&nbsp;&nbsp;•&nbsp;&nbsp;132 patches total
+> **[v1.37.0-dualvot.8.2](https://github.com/sashade8-ship-it/dual-vot-patches/releases/tag/v1.37.0-dualvot.8.2)**&nbsp;&nbsp;•&nbsp;&nbsp;`main`&nbsp;&nbsp;•&nbsp;&nbsp;132 patches total
 <details>
 <summary>📦 YouTube&nbsp;&nbsp;•&nbsp;&nbsp;74 patches</summary>
 <br>

--- a/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/VoiceOverTranslationButton.java
+++ b/extensions/youtube/src/main/java/app/morphe/extension/youtube/videoplayer/VoiceOverTranslationButton.java
@@ -18,7 +18,7 @@ import java.lang.ref.WeakReference;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
-import app.morphe.extension.youtube.patches.voiceovertranslation.VoiceOverTranslationCoordinator;
+import app.morphe.extension.youtube.patches.voiceovertranslation.VoiceOverTranslationPatch;
 import app.morphe.extension.youtube.patches.voiceovertranslation.VotBottomSheet;
 import app.morphe.extension.youtube.settings.Settings;
 
@@ -38,13 +38,15 @@ public final class VoiceOverTranslationButton {
         try {
             if (RESTORE_OLD_PLAYER_BUTTONS || !Settings.VOT_ENABLED.get()) return;
 
-            VoiceOverTranslationCoordinator.addOnStateChangeCallback(STATE_REFRESH_CALLBACK);
+            app.morphe.extension.youtube.patches.voiceovertranslation.VoiceOverTranslationCoordinator
+                    .addOnStateChangeCallback(STATE_REFRESH_CALLBACK);
 
             ImageView button = PlayerOverlayButton.addButton(
                     controlsView,
                     "morphe_yt_vot_bold",
                     view -> {
-                        VoiceOverTranslationCoordinator.toggleOfficial();
+                        app.morphe.extension.youtube.patches.voiceovertranslation
+                                .VoiceOverTranslationCoordinator.toggleOfficial();
                         refreshActivatedState();
                     },
                     view -> {
@@ -63,7 +65,8 @@ public final class VoiceOverTranslationButton {
         try {
             if (!RESTORE_OLD_PLAYER_BUTTONS) return;
 
-            VoiceOverTranslationCoordinator.addOnStateChangeCallback(STATE_REFRESH_CALLBACK);
+            app.morphe.extension.youtube.patches.voiceovertranslation.VoiceOverTranslationCoordinator
+                    .addOnStateChangeCallback(STATE_REFRESH_CALLBACK);
 
             legacy = new LegacyPlayerControlButton(
                     controlsView,
@@ -72,7 +75,8 @@ public final class VoiceOverTranslationButton {
                     "morphe_yt_vot",
                     Settings.VOT_ENABLED,
                     view -> {
-                        VoiceOverTranslationCoordinator.toggleOfficial();
+                        app.morphe.extension.youtube.patches.voiceovertranslation
+                                .VoiceOverTranslationCoordinator.toggleOfficial();
                         refreshActivatedState();
                     },
                     view -> {
@@ -88,7 +92,11 @@ public final class VoiceOverTranslationButton {
     private static void refreshActivatedState() {
         Utils.verifyOnMainThread();
         try {
-            final int alpha = VoiceOverTranslationCoordinator.isOfficialActive() ? 255 : 128;
+            final int alpha =
+                    app.morphe.extension.youtube.patches.voiceovertranslation
+                                    .VoiceOverTranslationCoordinator.isOfficialActive()
+                            ? 255
+                            : 128;
             WeakReference<ImageView> ref = overlayButtonRef;
             ImageView overlay = ref != null ? ref.get() : null;
             if (overlay != null) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.37.0-dualvot.8.1
+version = 1.37.0-dualvot.8.2

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-07-30T15:14:42",
-  "description": "## Dual VoT Patches 1.37.0-dualvot.8.1\n\n### Yandex player button\n\n- Integrates the Yandex translation button with restored thin player controls.\n- Uses separate thin legacy and bold modern icons so each matches its player style.\n- Compacts all five optional controls in portrait and gives them balanced spacing in landscape, in both player styles.\n\n### Validation\n\n- Android patch bundle compiled successfully.\n- Both player styles and five-button portrait/landscape layouts were tested on a device.\n- Required Dual VoT integration sources, metadata, and bundle manifest were verified.\n\n### Included base\n\n- Based on stable Morphe Patches 1.37.0.\n- Includes both the built-in Google/other translation and Yandex translation with mutually exclusive player controls.",
-  "download_url": "https://github.com/sashade8-ship-it/dual-vot-patches/releases/download/v1.37.0-dualvot.8.1/patches-1.37.0-dualvot.8.1.mpp",
+  "created_at": "2026-07-30T23:01:52",
+  "description": "## Dual VoT Patches 1.37.0-dualvot.8.2\n\n### Upstream sync compatibility\n\n- Prevents a three-way import conflict in the official voice-over translation player button when Morphe changes the legacy-controls access style.\n- Keeps all Dual VoT coordinator behavior unchanged while allowing future Morphe updates to merge automatically.\n\n### Validation\n\n- Android patch bundle compiled successfully.\n- All 11 upstream automation regression tests passed.\n- Required Dual VoT integration sources, metadata, and bundle manifest were verified.\n\n### Included base\n\n- Based on stable Morphe Patches 1.37.0.\n- Includes both the built-in Google/other translation and Yandex translation with mutually exclusive player controls.",
+  "download_url": "https://github.com/sashade8-ship-it/dual-vot-patches/releases/download/v1.37.0-dualvot.8.2/patches-1.37.0-dualvot.8.2.mpp",
   "signature_download_url": "",
-  "version": "1.37.0-dualvot.8.1"
+  "version": "1.37.0-dualvot.8.2"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.37.0-dualvot.8.1",
+  "version": "1.37.0-dualvot.8.2",
   "patches": [
     {
       "name": "Add to queue",


### PR DESCRIPTION
## What changed

- makes the Dual VoT official translation button compatible with Morphe's
  updated legacy-controls access style;
- keeps coordinator behavior unchanged;
- prepares stable version and Manager metadata for
  `1.37.0-dualvot.8.2`.

## Root cause

Morphe and Dual VoT changed adjacent imports in
`VoiceOverTranslationButton.java`. Git could not safely combine the two sides,
so the upstream updater correctly stopped instead of publishing an uncertain
merge.

The coordinator calls are now explicitly qualified while the pre-merge import
block remains compatible with the shared base. This removes the three-way
source conflict without weakening updater validation.

## Validation

- `python .github/scripts/test_sync_upstream.py` — 11 tests passed.
- `git diff --check` — passed.
- Active stable metadata, catalogue header, Gradle version and download URL all
  use `1.37.0-dualvot.8.2`.
- The local test-only `fix-dev3` suffix is absent from release metadata.
