### PR TITLE
release: Dual VoT 1.38.0-dev.3-dualvot.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.38.0-dev.3-dualvot.8.2 (2026-07-30)
+
+### Upstream sync compatibility
+
+* Record the conflict-safe official translation button integration as the new
+  Dual VoT revision 8.2.
+* Keep coordinator behavior unchanged and preserve automatic compatibility
+  with future Morphe updates.
+
 ## 1.38.0-dev.3-dualvot.8.1 (2026-07-30)
 
 ### Automated Morphe update

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ All modifications made by Morphe, along with their dates, can be found in the Gi
 #### Patches list
 
 <!-- PATCHES_START -->
-> **[v1.38.0-dev.3-dualvot.8.1](https://github.com/sashade8-ship-it/dual-vot-patches/releases/tag/v1.38.0-dev.3-dualvot.8.1)**&nbsp;&nbsp;•&nbsp;&nbsp;`dev`&nbsp;&nbsp;•&nbsp;&nbsp;133 patches total
+> **[v1.38.0-dev.3-dualvot.8.2](https://github.com/sashade8-ship-it/dual-vot-patches/releases/tag/v1.38.0-dev.3-dualvot.8.2)**&nbsp;&nbsp;•&nbsp;&nbsp;`dev`&nbsp;&nbsp;•&nbsp;&nbsp;133 patches total
 <details>
 <summary>📦 YouTube&nbsp;&nbsp;•&nbsp;&nbsp;75 patches</summary>
 <br>

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.38.0-dev.3-dualvot.8.1
+version = 1.38.0-dev.3-dualvot.8.2

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-07-30T20:50:41",
-  "description": "## Dual VoT Patches 1.38.0-dev.3-dualvot.8.1\n\nPre-release automated update based on Morphe Patches 1.38.0-dev.3.\n\n### Included\n\n- Google/other and Yandex voice-over translation in one patch bundle.\n- Separate player controls with mutual exclusion.\n- Dual VoT volume controls and automatic reset when the video changes.\n- Requests for previously untranslated Yandex videos.\n\n### Validation\n\n- Android patch bundle compiled successfully.\n- Both translation patches are present in generated metadata.\n- Required Dual VoT integration sources and bundle manifest were verified.\n\nThis release was produced automatically. Runtime regressions that cannot be\ndetected by compilation should be reported in this repository.",
-  "download_url": "https://github.com/sashade8-ship-it/dual-vot-patches/releases/download/v1.38.0-dev.3-dualvot.8.1/patches-1.38.0-dev.3-dualvot.8.1.mpp",
+  "created_at": "2026-07-30T23:04:45",
+  "description": "## Dual VoT Patches 1.38.0-dev.3-dualvot.8.2\n\n### Upstream sync compatibility\n\n- Records the conflict-safe official translation button integration as Dual VoT revision 8.2.\n- Keeps all Dual VoT coordinator behavior unchanged while preserving automatic compatibility with future Morphe updates.\n\n### Validation\n\n- Android patch bundle compiled successfully.\n- All 11 upstream automation regression tests passed.\n- Both translation patches and required Dual VoT integration sources were verified.\n\n### Included base\n\n- Based on pre-release Morphe Patches 1.38.0-dev.3.\n- Includes both the built-in Google/other translation and Yandex translation with mutually exclusive player controls.",
+  "download_url": "https://github.com/sashade8-ship-it/dual-vot-patches/releases/download/v1.38.0-dev.3-dualvot.8.2/patches-1.38.0-dev.3-dualvot.8.2.mpp",
   "signature_download_url": "",
-  "version": "1.38.0-dev.3-dualvot.8.1"
+  "version": "1.38.0-dev.3-dualvot.8.2"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.38.0-dev.3-dualvot.8.1",
+  "version": "1.38.0-dev.3-dualvot.8.2",
   "patches": [
     {
       "name": "Add to queue",


### PR DESCRIPTION
## What changed

- records the conflict-safe official translation button integration as Dual
  VoT revision `8.2`;
- prepares dev version and Manager metadata for
  `1.38.0-dev.3-dualvot.8.2`;
- keeps the Morphe base at `1.38.0-dev.3` and leaves runtime coordinator
  behavior unchanged.

## Why

The source compatibility fix that restored the Morphe dev.3 updater belongs to
our integration revision. Publishing it as `dualvot.8.2` keeps stable and dev
on the same clear Dual VoT generation. The earlier `8.1` releases remain
immutable history.

## Validation

- `python .github/scripts/test_sync_upstream.py` — 11 tests passed.
- `git diff --check` — passed.
- Active dev metadata, catalogue header, Gradle version and download URL all
  use `1.38.0-dev.3-dualvot.8.2`.
- The local test-only `fix-dev3` suffix is absent from release metadata.
