### PR TITLE
fix: add a staggered upstream sync fallback

### DIFF
--- a/.github/scripts/test_sync_upstream.py
+++ b/.github/scripts/test_sync_upstream.py
@@ -14,11 +14,12 @@ SPEC.loader.exec_module(sync_upstream)
 
 
 class SyncUpstreamTests(unittest.TestCase):
-    def test_dispatcher_runs_every_two_hours(self):
+    def test_dispatcher_has_staggered_two_hour_schedules(self):
         workflow = (
             MODULE_PATH.parents[1] / "workflows" / "upstream_sync.yml"
         ).read_text(encoding="utf-8")
         self.assertIn("cron: '23 */2 * * *'", workflow)
+        self.assertIn("cron: '53 */2 * * *'", workflow)
         self.assertNotIn("cron: '23 */6 * * *'", workflow)
 
     def test_merges_only_dual_yandex_strings_into_upstream_resource(self):

--- a/.github/workflows/upstream_sync.yml
+++ b/.github/workflows/upstream_sync.yml
@@ -2,7 +2,10 @@ name: Sync Morphe upstream
 
 on:
   schedule:
+    # Keep two independent deliveries. GitHub may occasionally skip a scheduled
+    # event; the staggered fallback limits a single missed event to 90 minutes.
     - cron: '23 */2 * * *'
+    - cron: '53 */2 * * *'
   workflow_dispatch:
     inputs:
       channel:

--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -7,8 +7,11 @@ Dual VoT Patches tracks both Morphe release channels:
 | `main` | `main` | Stable | GitHub stable release |
 | `dev` | `dev` | Pre-release patches enabled | GitHub pre-release |
 
-The scheduled workflow checks both channels every two hours. It synchronizes
-exact Morphe release tags, not arbitrary unreleased branch commits.
+The scheduled workflow has two staggered, independent deliveries: each checks
+both channels every two hours, at minute `23` and minute `53` (UTC). This keeps
+the normal update cadence within two hours and limits a single missed GitHub
+schedule event to the next staggered delivery. It synchronizes exact Morphe
+release tags, not arbitrary unreleased branch commits.
 
 ## Safety model
 

--- a/README.md
+++ b/README.md
@@ -71,10 +71,11 @@ steps.
 - Enable **Pre-release patches** for this source in Morphe Manager to receive
   the `dev` channel. Leave it disabled for the stable channel.
 
-Both channels are checked automatically every six hours. An update is
-published only after the bundle compiles and the Dual VoT integration passes
-structural checks. Merge conflicts or failed builds stop publication and open
-an issue without replacing the previous working release. See
+Both channels are checked automatically at least every two hours through two
+staggered GitHub schedules. An update is published only after the bundle
+compiles and the Dual VoT integration passes structural checks. Merge conflicts
+or failed builds stop publication and open an issue without replacing the
+previous working release. See
 [automatic upstream updates](AUTOMATION.md) for details.
 
 ## Credits and license


### PR DESCRIPTION
Adds a second two-hour GitHub schedule at a different minute, while preserving the existing concurrency guard. A missed single schedule delivery is followed by the fallback within 90 minutes. Documentation and regression coverage are updated.