### PR TITLE
fix: keep dev automation controller in sync

### DIFF
--- a/.github/scripts/sync_upstream.py
+++ b/.github/scripts/sync_upstream.py
@@ -47,6 +47,21 @@ PROJECT_OWNED_PATHS = (
     ".github/scripts/sync_upstream.py",
 )
 
+# The updater itself always runs from main.  When it first joins a newer stable
+# branch into dev, retain that controller instead of the historical copy in dev;
+# otherwise a controller test or workflow change can leave the published dev
+# branch red even though the candidate build succeeded.
+CONTROLLER_PATHS = (
+    ".github/workflows/crowdin_pull.yml",
+    ".github/workflows/crowdin_push.yml",
+    ".github/workflows/build_pull_request.yml",
+    ".github/workflows/release.yml",
+    ".github/workflows/upstream_sync.yml",
+    ".github/workflows/upstream_sync_channel.yml",
+    ".github/scripts/sync_upstream.py",
+    ".github/scripts/test_sync_upstream.py",
+)
+
 UPSTREAM_FILES_REMOVED_FROM_DERIVATIVE = (
     ".github/workflows/open_pull_request.yml",
     "patches-bundle.png",
@@ -317,7 +332,12 @@ def resolve_addon_compatibility_conflicts() -> None:
         restore_path_from("HEAD", path)
 
 
-def merge_ref(ref: str, project_preference: str, label: str) -> bool:
+def merge_ref(
+    ref: str,
+    project_preference: str,
+    label: str,
+    controller_preference: str | None = None,
+) -> bool:
     """Merge ref without committing and resolve only explicitly owned files.
 
     Unknown source conflicts stop the automation. This is the central guard
@@ -335,6 +355,11 @@ def merge_ref(ref: str, project_preference: str, label: str) -> bool:
     preferred_ref = "HEAD" if project_preference == "ours" else "MERGE_HEAD"
     for path in PROJECT_OWNED_PATHS:
         restore_path_from(preferred_ref, path)
+
+    if controller_preference is not None:
+        controller_ref = "HEAD" if controller_preference == "ours" else "MERGE_HEAD"
+        for path in CONTROLLER_PATHS:
+            restore_path_from(controller_ref, path)
 
     # The upstream version is authoritative; the Dual suffix is added later.
     if "gradle.properties" in unresolved_paths():
@@ -672,6 +697,7 @@ def prepare(channel: str, output_dir: Path, repository: str) -> None:
             "origin/main",
             project_preference="theirs" if dev_matches_stable else "ours",
             label="the latest Dual VoT stable branch",
+            controller_preference="theirs",
         )
         local_version = bundle_version_from_git("HEAD")
         local_base = upstream_base(local_version)

--- a/.github/scripts/test_sync_upstream.py
+++ b/.github/scripts/test_sync_upstream.py
@@ -22,6 +22,34 @@ class SyncUpstreamTests(unittest.TestCase):
         self.assertIn("cron: '53 */2 * * *'", workflow)
         self.assertNotIn("cron: '23 */6 * * *'", workflow)
 
+    def test_dev_merge_keeps_metadata_but_refreshes_controller_from_main(self):
+        calls = []
+
+        def fake_run(*args, **_kwargs):
+            returncode = 1 if args[1:3] == ("merge-base", "--is-ancestor") else 0
+            return mock.Mock(returncode=returncode)
+
+        with (
+            mock.patch.object(sync_upstream, "output_of", side_effect=("before", "after")),
+            mock.patch.object(sync_upstream, "run", side_effect=fake_run),
+            mock.patch.object(sync_upstream, "restore_path_from", side_effect=lambda ref, path: calls.append((ref, path))),
+            mock.patch.object(sync_upstream, "unresolved_paths", return_value=[]),
+            mock.patch.object(sync_upstream, "resolve_dual_yandex_string_conflicts"),
+            mock.patch.object(sync_upstream, "resolve_addon_compatibility_conflicts"),
+        ):
+            self.assertTrue(
+                sync_upstream.merge_ref(
+                    "origin/main",
+                    project_preference="ours",
+                    label="stable branch",
+                    controller_preference="theirs",
+                )
+            )
+
+        self.assertIn(("HEAD", "README.md"), calls)
+        for path in sync_upstream.CONTROLLER_PATHS:
+            self.assertIn(("MERGE_HEAD", path), calls)
+
     def test_dev3_volume_hook_keeps_dual_coordinator(self):
         root = MODULE_PATH.parents[2]
         patch = (

--- a/.github/workflows/upstream_sync.yml
+++ b/.github/workflows/upstream_sync.yml
@@ -2,7 +2,10 @@ name: Sync Morphe upstream
 
 on:
   schedule:
+    # Keep two independent deliveries. GitHub may occasionally skip a scheduled
+    # event; the staggered fallback limits a single missed event to 90 minutes.
     - cron: '23 */2 * * *'
+    - cron: '53 */2 * * *'
   workflow_dispatch:
     inputs:
       channel:


### PR DESCRIPTION
Fix the post-publish Dev3 CI regression and prevent the same main-to-dev controller drift in future upstream syncs.\n\n- preserves fork metadata from dev\n- takes workflow/controller files from main during the technical main-to-dev merge\n- carries the staggered schedule into dev for branch CI\n\nValidated locally: python .github/scripts/test_sync_upstream.py (20 tests), git diff --check.